### PR TITLE
fix: escape resource overlap regex patterns

### DIFF
--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -8,7 +8,11 @@ import type { ResourceExplain } from '../explain/statementExplain.js'
 import type { PolicyType } from '../policyType.js'
 import { AwsRequestImpl } from '../request/request.js'
 import { RequestContextImpl } from '../requestContext.js'
-import { requestMatchesNotResources, requestMatchesResources } from './resource.js'
+import {
+  requestMatchesNotResources,
+  requestMatchesResources,
+  resourcePatternOverlap
+} from './resource.js'
 
 type ResourceStatements =
   | {
@@ -93,6 +97,21 @@ const resourceTests: ResourceTest[] = [
     explains: [
       {
         resource: 'arn:???:s3:::my_corporate_bucket',
+        matches: true
+      }
+    ]
+  },
+  {
+    name: 'should match a policy resource with leading question mark wildcards against a wildcard request resource',
+    resourceStatements: ['arn:aws:s3:::??-example-bucket/data/*/_logs/*'],
+    resource: {
+      resource: 'arn:aws:s3:::ab-example-bucket/data/v1/table/_logs/*',
+      accountId: '123456789012'
+    },
+    expectMatch: true,
+    explains: [
+      {
+        resource: 'arn:aws:s3:::??-example-bucket/data/*/_logs/*',
         matches: true
       }
     ]
@@ -1876,6 +1895,32 @@ function validateExplains(expected: ResourceExplain[], actual: ResourceExplain[]
     }
   }
 }
+
+describe('resourcePatternOverlap', () => {
+  it('should treat leading question marks in policy patterns as IAM wildcards instead of regex quantifiers', () => {
+    //Given a policy resource pattern that starts with question mark wildcards
+    const policyResource = '??-example-bucket/data/v1/*/_logs/*'
+    const wildcardRequestResource = 'ab-example-bucket/data/v1/table/_logs/*'
+
+    //When the resource patterns are compared for overlap
+    const result = resourcePatternOverlap(policyResource, wildcardRequestResource)
+
+    //Then the policy pattern should be detected as a superset without throwing a SyntaxError
+    expect(result).toBe('policy_is_superset')
+  })
+
+  it('should treat question marks in request patterns as literals instead of regex quantifiers', () => {
+    //Given a wildcard request resource that contains literal question marks
+    const policyResource = 'ab-example-bucket/data/v1/table/_logs/object.json'
+    const wildcardRequestResource = '??-example-bucket/data/v1/*/_logs/*'
+
+    //When the resource patterns are compared for overlap
+    const result = resourcePatternOverlap(policyResource, wildcardRequestResource)
+
+    //Then unsupported request question marks should not create an invalid regular expression
+    expect(result).toBe('none')
+  })
+})
 
 describe('requestMatchesResources', () => {
   for (const rt of resourceTests) {

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -71,6 +71,44 @@ function convertResourceSegmentToRegex(segment: string): RegExp {
 }
 
 /**
+ * Replace regex characters in a resource pattern with escaped versions.
+ *
+ * @param pattern the resource pattern to escape for use inside a regular expression
+ * @returns the pattern with regex metacharacters escaped
+ */
+function escapeResourcePatternRegexCharacters(pattern: string): string {
+  return pattern.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
+/**
+ * Convert a request resource pattern to a regex string for overlap checks.
+ * Request resources support asterisks as wildcards, but question marks are literals.
+ *
+ * @param requestString the request resource pattern to convert
+ * @returns a regex string that matches the request resource pattern
+ */
+function requestResourcePatternToRegexString(requestString: string): string {
+  return '^' + escapeResourcePatternRegexCharacters(requestString).replace(/\\\*/g, '.*?') + '$'
+}
+
+/**
+ * Convert a policy resource pattern to a regex string for overlap checks.
+ * Policy resources support asterisks and question marks as IAM wildcards.
+ *
+ * @param policyString the policy resource pattern to convert
+ * @returns a regex string that matches the policy resource pattern
+ */
+function policyResourcePatternToRegexString(policyString: string): string {
+  return (
+    '^' +
+    escapeResourcePatternRegexCharacters(policyString)
+      .replace(/\\\?/g, '.')
+      .replace(/\\\*/g, '.*?') +
+    '$'
+  )
+}
+
+/**
  * Check if a request matches the Resource or NotResource elements of a statement.
  *
  * @param request the request to check
@@ -477,12 +515,12 @@ export function resourcePatternOverlap(
   if (policyString === requestString) {
     return 'equal'
   }
-  const requestPattern = '^' + requestString.replace(/\*/g, '.*?') + '$'
+  const requestPattern = requestResourcePatternToRegexString(requestString)
   if (policyString.match(requestPattern)) {
     return 'policy_is_subset'
   }
 
-  const policyPattern = '^' + policyString.replace(/\?/g, '.').replace(/\*/g, '.*?') + '$'
+  const policyPattern = policyResourcePatternToRegexString(policyString)
   if (requestString.match(policyPattern)) {
     return 'policy_is_superset'
   }


### PR DESCRIPTION
## Summary
- Escape regex metacharacters before converting resource overlap patterns to regular expressions
- Preserve IAM wildcard semantics for policy-side `?` and `*`
- Treat request-side `?` as a literal while continuing to support request-side `*` wildcards
