### PR TITLE
fix: handle wildcard resource intersections

### DIFF
--- a/src/core_engine/coreEngineTests/resourceWildcards/crossPatternIntersections.json
+++ b/src/core_engine/coreEngineTests/resourceWildcards/crossPatternIntersections.json
@@ -1,0 +1,267 @@
+[
+  {
+    "name": "Cross-account Allow Resource wildcard intersection: AWSLogs prefix overlaps bucket wildcard",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*/AWSLogs/*"
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::example-bucket/*"
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Cross-account Allow Resource wildcard intersection: nested AWSLogs prefix overlaps bucket wildcard",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*/*/AWSLogs/*"
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::example-bucket/*"
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Cross-account Allow Resource wildcard intersection: object extension pattern overlaps bucket wildcard",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": ["arn:aws:s3:::*/*.iso", "arn:aws:s3:::*/*.ISO"]
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::example-bucket/*"
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Cross-account Allow Resource wildcard intersection: generated prefix overlaps bucket wildcard",
+    "request": {
+      "action": "s3:PutObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["s3:GetObject", "s3:PutObject"],
+            "Resource": "arn:aws:s3:::*/generated-prefix-*"
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Action": ["s3:GetObject", "s3:PutObject"],
+          "Resource": "arn:aws:s3:::example-bucket/*"
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Cross-account Allow Resource wildcard intersection: global S3 resource wildcard overlaps bucket object wildcard",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*"
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::example-bucket/*"
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Cross-account Allow Resource wildcard intersection: disjoint identity pattern remains denied",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::other-bucket/*"
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::example-bucket/*"
+        }
+      ]
+    },
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
+  },
+  {
+    "name": "Deny Resource wildcard partial overlap does not deny the entire wildcard request",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/*",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/ExampleRole"
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::example-bucket/*"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::*/AWSLogs/*"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  }
+]

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -1909,6 +1909,18 @@ describe('resourcePatternOverlap', () => {
     expect(result).toBe('policy_is_superset')
   })
 
+  it('should detect non-empty intersections where neither wildcard pattern contains the other', () => {
+    //Given policy and request resource patterns that overlap on some concrete resources
+    const policyResource = 'arn:aws:s3:::example-bucket/*'
+    const wildcardRequestResource = 'arn:aws:s3:::*/AWSLogs/*'
+
+    //When the resource patterns are compared for overlap
+    const result = resourcePatternOverlap(policyResource, wildcardRequestResource)
+
+    //Then the partial intersection should be detected
+    expect(result).toBe('overlap')
+  })
+
   it('should treat question marks in request patterns as literals instead of regex quantifiers', () => {
     //Given a wildcard request resource that contains literal question marks
     const policyResource = 'ab-example-bucket/data/v1/table/_logs/object.json'

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -506,12 +506,12 @@ function singleResourceMatchesRequest(
  *
  * @param policyString the policy string to use
  * @param requestString the request string to compare to the policy string
- * @returns 'equal' if the strings are equal, 'subset' if the policy string is a subset of the request string, 'superset' if the policy string is a superset of the request string, or 'none' if there is no overlap
+ * @returns 'equal' if the strings are equal, 'subset' if the policy string is a subset of the request string, 'superset' if the policy string is a superset of the request string, 'overlap' if the strings have a non-empty intersection but neither contains the other, or 'none' if there is no overlap
  */
 export function resourcePatternOverlap(
   policyString: string,
   requestString: string
-): 'equal' | 'policy_is_subset' | 'policy_is_superset' | 'none' {
+): 'equal' | 'policy_is_subset' | 'policy_is_superset' | 'overlap' | 'none' {
   if (policyString === requestString) {
     return 'equal'
   }
@@ -525,5 +525,134 @@ export function resourcePatternOverlap(
     return 'policy_is_superset'
   }
 
+  if (resourcePatternsIntersect(policyString, requestString)) {
+    return 'overlap'
+  }
+
   return 'none'
+}
+
+/**
+ * Checks whether a policy resource pattern and request resource pattern share
+ * at least one concrete resource string.
+ *
+ * Policy patterns use IAM `*` and `?` wildcards. Request patterns only treat
+ * `*` as a wildcard; `?` remains literal to match the existing request
+ * wildcard semantics in this module.
+ *
+ * @param policyString the policy-side resource pattern segment to compare
+ * @param requestString the request-side resource pattern segment to compare
+ * @returns true when the patterns have a non-empty intersection
+ */
+function resourcePatternsIntersect(policyString: string, requestString: string): boolean {
+  const policyPattern = [...policyString]
+  const requestPattern = [...requestString]
+  const visited = new Set<string>()
+  const queue: Array<[number, number]> = [[0, 0]]
+  const key = (policyIndex: number, requestIndex: number) => `${policyIndex},${requestIndex}`
+
+  while (queue.length > 0) {
+    const [policyIndex, requestIndex] = queue.shift()!
+    const stateKey = key(policyIndex, requestIndex)
+    if (visited.has(stateKey)) {
+      continue
+    }
+    visited.add(stateKey)
+
+    if (policyIndex === policyPattern.length && requestIndex === requestPattern.length) {
+      return true
+    }
+
+    const policyToken = tokenAt(policyPattern, policyIndex)
+    const requestToken = tokenAt(requestPattern, requestIndex)
+
+    if (policyToken === '*') {
+      queue.push([policyIndex + 1, requestIndex])
+    }
+    if (requestToken === '*') {
+      queue.push([policyIndex, requestIndex + 1])
+    }
+
+    if (resourcePatternTokensCanConsumeSameCharacter(policyToken, requestToken)) {
+      const nextPolicyIndexes = nextResourcePatternIndexesAfterOneCharacter(
+        policyPattern,
+        policyIndex,
+        true
+      )
+      const nextRequestIndexes = nextResourcePatternIndexesAfterOneCharacter(
+        requestPattern,
+        requestIndex,
+        false
+      )
+      for (const nextPolicyIndex of nextPolicyIndexes) {
+        for (const nextRequestIndex of nextRequestIndexes) {
+          queue.push([nextPolicyIndex, nextRequestIndex])
+        }
+      }
+    }
+  }
+
+  return false
+}
+
+/**
+ * Reads a token from a pattern, returning null at the end of the pattern.
+ *
+ * @param pattern the pattern characters
+ * @param index the index to read
+ * @returns the token at the index, or null when the index is past the end
+ */
+function tokenAt(pattern: string[], index: number): string | null {
+  return index < pattern.length ? pattern[index] : null
+}
+
+/**
+ * Determines whether policy and request pattern tokens can match the same next
+ * concrete character under their respective wildcard semantics.
+ *
+ * @param policyToken token from the policy pattern, where `*` and `?` are wildcards
+ * @param requestToken token from the request pattern, where only `*` is a wildcard
+ * @returns true if both tokens can consume the same concrete character
+ */
+function resourcePatternTokensCanConsumeSameCharacter(
+  policyToken: string | null,
+  requestToken: string | null
+): boolean {
+  if (policyToken === null || requestToken === null) {
+    return false
+  }
+
+  const policyWildcard = policyToken === '*' || policyToken === '?'
+  const requestWildcard = requestToken === '*'
+  if (!policyWildcard && !requestWildcard) {
+    return policyToken === requestToken
+  }
+
+  return true
+}
+
+/**
+ * Returns possible next indexes after consuming one concrete character from a pattern.
+ *
+ * @param pattern the pattern characters
+ * @param index current pattern index
+ * @param questionMarkIsWildcard whether `?` should be treated as a one-character wildcard
+ * @returns possible next indexes after one concrete character is consumed
+ */
+function nextResourcePatternIndexesAfterOneCharacter(
+  pattern: string[],
+  index: number,
+  questionMarkIsWildcard: boolean
+): number[] {
+  const token = tokenAt(pattern, index)
+  if (token === null) {
+    return []
+  }
+  if (token === '*') {
+    return [index]
+  }
+  if (token === '?' && questionMarkIsWildcard) {
+    return [index + 1]
+  }
+  return [index + 1]
 }

--- a/src/simulation_engine/simulationEngine.test.ts
+++ b/src/simulation_engine/simulationEngine.test.ts
@@ -119,7 +119,9 @@ vi.mocked(iamConditionKeyExists).mockImplementation(async (service, key) => {
 vi.mocked(iamActionExists).mockImplementation(async (service, action) => {
   return (
     (service === 's3' &&
-      ['GetObjects', 'GetObject', 'ListAllMyBuckets', 'ListBucket'].includes(action)) ||
+      ['GetObjects', 'GetObject', 'PutObject', 'ListAllMyBuckets', 'ListBucket'].includes(
+        action
+      )) ||
     (service === 'ssm' && ['GetParameter', 'DescribeParameters'].includes(action))
   )
 })
@@ -161,12 +163,12 @@ vi.mocked(getGlobalConditionKeyByName).mockImplementation((key) => {
 })
 
 vi.mocked(iamActionDetails).mockImplementation(async (service, actionKey) => {
-  if (actionKey === 'GetObject') {
+  if (actionKey === 'GetObject' || actionKey === 'PutObject') {
     return {
-      accessLevel: 'Read',
+      accessLevel: actionKey === 'GetObject' ? 'Read' : 'Write',
       conditionKeys: ['s3:RequestObjectTagKeys', 's3:ResourceAccount'],
-      description: 'Grants permission to retrieve objects from Amazon S3 buckets',
-      name: 'GetObject',
+      description: `Grants permission to ${actionKey === 'GetObject' ? 'retrieve' : 'write'} objects in Amazon S3 buckets`,
+      name: actionKey,
       resourceTypes: [
         {
           name: 'object',
@@ -1378,6 +1380,163 @@ describe('runSimulation', () => {
     //Then there should be no errors
     //And the ignored context keys should be empty
     expect(result.ignoredContextKeys).toEqual([])
+  })
+
+  it.each([
+    {
+      name: 'AWSLogs prefix under any bucket',
+      action: 's3:GetObject',
+      identityResource: 'arn:aws:s3:::*/AWSLogs/*',
+      resourcePolicyAction: 's3:GetObject',
+      exampleConcreteResource: 'arn:aws:s3:::example-bucket/AWSLogs/test.log'
+    },
+    {
+      name: 'nested AWSLogs prefix under any bucket',
+      action: 's3:GetObject',
+      identityResource: 'arn:aws:s3:::*/*/AWSLogs/*',
+      resourcePolicyAction: 's3:GetObject',
+      exampleConcreteResource: 'arn:aws:s3:::example-bucket/prefix/AWSLogs/test.log'
+    },
+    {
+      name: 'lowercase ISO extension under any bucket',
+      action: 's3:GetObject',
+      identityResource: 'arn:aws:s3:::*/*.iso',
+      resourcePolicyAction: 's3:GetObject',
+      exampleConcreteResource: 'arn:aws:s3:::example-bucket/image.iso'
+    },
+    {
+      name: 'service-generated prefix under any bucket',
+      action: 's3:PutObject',
+      identityResource: 'arn:aws:s3:::*/generated-prefix-*',
+      resourcePolicyAction: 's3:PutObject',
+      exampleConcreteResource: 'arn:aws:s3:::example-bucket/generated-prefix-123'
+    }
+  ])(
+    'should allow a cross-account wildcard request when the identity and resource policy patterns overlap for $name',
+    async ({ action, identityResource, resourcePolicyAction, exampleConcreteResource }) => {
+      //Given a cross-account S3 object request where the identity and resource policy resource patterns overlap
+      const simulation: Simulation = {
+        identityPolicies: [
+          {
+            name: 'identityPolicy',
+            policy: {
+              Version: '2012-10-17',
+              Statement: [
+                {
+                  Effect: 'Allow',
+                  Action: action,
+                  Resource: identityResource
+                }
+              ]
+            }
+          }
+        ],
+        serviceControlPolicies: [],
+        resourceControlPolicies: [],
+        resourcePolicy: {
+          Version: '2012-10-17',
+          Statement: [
+            {
+              Effect: 'Allow',
+              Principal: { AWS: 'arn:aws:iam::111111111111:root' },
+              Action: resourcePolicyAction,
+              Resource: 'arn:aws:s3:::example-bucket/*'
+            }
+          ]
+        },
+        request: {
+          action,
+          resource: {
+            resource: 'arn:aws:s3:::example-bucket/*',
+            accountId: '222222222222'
+          },
+          principal: 'arn:aws:iam::111111111111:role/ExampleRole',
+          contextVariables: {}
+        }
+      }
+
+      const concreteSimulation: Simulation = {
+        ...simulation,
+        request: {
+          ...simulation.request,
+          resource: {
+            ...simulation.request.resource,
+            resource: exampleConcreteResource
+          }
+        }
+      }
+
+      //When the wildcard and concrete simulations are run
+      const response = await runSimulation(simulation, {})
+      const concreteResponse = await runSimulation(concreteSimulation, {})
+
+      //Then a concrete resource in the intersection should already be allowed
+      expect(concreteResponse.resultType).toEqual('single')
+      if (concreteResponse.resultType !== 'single') {
+        throw new Error('Expected single result')
+      }
+      expect(concreteResponse.overallResult).toEqual('Allowed')
+
+      //And the overlapping subset should make the wildcard request allowed too
+      expect(response.resultType).toEqual('wildcard')
+      if (response.resultType !== 'wildcard') {
+        throw new Error('Expected wildcard result')
+      }
+      expect(response.overallResult).toEqual('Allowed')
+    }
+  )
+
+  it('should keep a cross-account wildcard request denied when identity and resource policy patterns do not overlap', async () => {
+    //Given a cross-account S3 object request where identity and resource policy patterns are disjoint
+    const simulation: Simulation = {
+      identityPolicies: [
+        {
+          name: 'identityPolicy',
+          policy: {
+            Version: '2012-10-17',
+            Statement: [
+              {
+                Effect: 'Allow',
+                Action: 's3:GetObject',
+                Resource: 'arn:aws:s3:::other-bucket/*'
+              }
+            ]
+          }
+        }
+      ],
+      serviceControlPolicies: [],
+      resourceControlPolicies: [],
+      resourcePolicy: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: { AWS: 'arn:aws:iam::111111111111:root' },
+            Action: 's3:GetObject',
+            Resource: 'arn:aws:s3:::example-bucket/*'
+          }
+        ]
+      },
+      request: {
+        action: 's3:GetObject',
+        resource: {
+          resource: 'arn:aws:s3:::example-bucket/*',
+          accountId: '222222222222'
+        },
+        principal: 'arn:aws:iam::111111111111:role/ExampleRole',
+        contextVariables: {}
+      }
+    }
+
+    //When the wildcard simulation is run
+    const response = await runSimulation(simulation, {})
+
+    //Then no synthesized candidate should make the disjoint request allowed
+    expect(response.resultType).toEqual('wildcard')
+    if (response.resultType !== 'wildcard') {
+      throw new Error('Expected wildcard result')
+    }
+    expect(response.overallResult).toEqual('ImplicitlyDenied')
   })
 
   it('should return not allowed without erroring when an identity policy has a CloudFormation Sub resource string', async () => {


### PR DESCRIPTION
## Summary
- detect non-empty intersections between policy and request wildcard resource patterns during resource matching
- cover cross-account S3 wildcard intersection cases from the bug report
- add resource-level and core-engine regression coverage, including disjoint and deny partial-overlap controls

## Tests
- npx vitest --run src/resource/resource.test.ts -t "resourcePatternOverlap"
- npx vitest --run src/simulation_engine/simulationEngine.test.ts -t "should allow a cross-account wildcard request when the identity and resource policy patterns overlap|should keep a cross-account wildcard request denied"
- npx vitest --run src/core_engine/coreSimulatorEngine.test.ts -t "crossPatternIntersections|Cross-account Allow Resource wildcard intersection|Deny Resource wildcard partial overlap"
- npm run format-check
- npm run build
- npm test

## Notes
The fix lives in resource pattern matching rather than wildcard candidate synthesis so both identity and resource policy evaluation use the same overlap semantics.