### PR TITLE
fix: match pathed role principals to role sessions

### DIFF
--- a/src/principal/principal.test.ts
+++ b/src/principal/principal.test.ts
@@ -439,6 +439,125 @@ describe('requestMatchesPrincipalStatement', () => {
       expect(result.explain.matches).toBe('SessionRoleMatch')
     })
 
+    it('role arn with a path matches an assumed-role session for the role name', () => {
+      //Given a policy principal statement for a role with a path
+      const policy = loadPolicy({
+        Statement: [{ Principal: { AWS: 'arn:aws:iam::555555555555:role/org/team/super-admin' } }]
+      })
+
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+
+      //And a request with an assumed-role session for that role name
+      const request = new AwsRequestImpl(
+        'arn:aws:sts::555555555555:assumed-role/super-admin/session-name',
+        defaultResource,
+        's3:GetBucket',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then it should match the role for the session
+      expect(result.explain.matches).toBe('SessionRoleMatch')
+      expect(result.explain.principal).toBe('arn:aws:iam::555555555555:role/org/team/super-admin')
+      expect(result.explain.roleForSessionArn).toBe(
+        'arn:aws:iam::555555555555:role/org/team/super-admin'
+      )
+    })
+
+    it('role arn with a path matches an assumed-role session for the role name ignoring case', () => {
+      //Given a policy principal statement for a role with uppercase characters in the name
+      const policy = loadPolicy({
+        Statement: [{ Principal: { AWS: 'arn:aws:iam::555555555555:role/team/Super-Admin' } }]
+      })
+
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+
+      //And a request with an assumed-role session for that role name using different casing
+      const request = new AwsRequestImpl(
+        'arn:aws:sts::555555555555:assumed-role/super-admin/session-name',
+        defaultResource,
+        's3:GetBucket',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then it should match the role for the session
+      expect(result.explain.matches).toBe('SessionRoleMatch')
+      expect(result.explain.roleForSessionArn).toBe(
+        'arn:aws:iam::555555555555:role/team/Super-Admin'
+      )
+    })
+
+    it('role arn with a path does not match a session for a different role name', () => {
+      //Given a policy principal statement for a role with a path
+      const policy = loadPolicy({
+        Statement: [{ Principal: { AWS: 'arn:aws:iam::555555555555:role/team/super-admin' } }]
+      })
+
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+
+      //And a request with an assumed-role session for a different role name
+      const request = new AwsRequestImpl(
+        'arn:aws:sts::555555555555:assumed-role/normie-admin/session-name',
+        defaultResource,
+        's3:GetBucket',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then it should not match
+      expect(result.explain.matches).toBe('NoMatch')
+    })
+
+    it('role arn with a path does not match a session from a different account', () => {
+      //Given a policy principal statement for a role with a path
+      const policy = loadPolicy({
+        Statement: [{ Principal: { AWS: 'arn:aws:iam::555555555555:role/team/super-admin' } }]
+      })
+
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+
+      //And a request with an assumed-role session for the same role name in a different account
+      const request = new AwsRequestImpl(
+        'arn:aws:sts::444444444444:assumed-role/super-admin/session-name',
+        defaultResource,
+        's3:GetBucket',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then it should not match
+      expect(result.explain.matches).toBe('NoMatch')
+    })
+
     it('neither session nor role arn matches', () => {
       //Given a policy principal statement
       const policy = loadPolicy({

--- a/src/principal/principal.ts
+++ b/src/principal/principal.ts
@@ -2,7 +2,9 @@ import { type Principal, type Statement } from '@cloud-copilot/iam-policy'
 import {
   convertAssumedRoleArnToRoleArn,
   isAssumedRoleArn,
-  isFederatedUserArn
+  isFederatedUserArn,
+  isIamRoleArn,
+  splitArnParts
 } from '@cloud-copilot/iam-utils'
 import { type SimulationParameters } from '../core_engine/CoreSimulatorEngine.js'
 import { type PrincipalExplain, type StatementExplain } from '../explain/statementExplain.js'
@@ -259,13 +261,12 @@ export function requestMatchesPrincipalStatement(
   if (principalStatement.isAwsPrincipal()) {
     if (isAssumedRoleArn(request.principal.value())) {
       const sessionArn = request.principal.value()
-      const roleArn = convertAssumedRoleArnToRoleArn(sessionArn)
-      if (principalStatement.arn() === roleArn) {
+      if (roleArnMatchesAssumedRoleSession(principalStatement.arn(), sessionArn)) {
         return {
           explain: {
             matches: 'SessionRoleMatch',
             principal: principalStatement.value(),
-            roleForSessionArn: roleArn
+            roleForSessionArn: principalStatement.arn()
           }
         }
       }
@@ -344,6 +345,72 @@ export function userArnFromFederatedUserArn(federatedUserArn: string): string {
   const resource = stsParts.at(-1)!
   const username = resource.slice(resource.indexOf('/') + 1)
   return `arn:${stsParts[1]}:iam::${stsParts[4]}:user/${username}`
+}
+
+/**
+ * Get the final segment from a slash-delimited path.
+ *
+ * @param path the slash-delimited path to inspect
+ * @returns the final path segment, or undefined if the path is undefined or empty
+ */
+function lastPathSegment(path: string | undefined): string | undefined {
+  if (!path) {
+    return undefined
+  }
+
+  const lastSlashIndex = path.lastIndexOf('/')
+  if (lastSlashIndex === -1) {
+    return path
+  }
+  return path.slice(lastSlashIndex + 1)
+}
+
+/**
+ * Get the first segment from a slash-delimited path.
+ *
+ * @param path the slash-delimited path to inspect
+ * @returns the first path segment, or undefined if the path is undefined, empty, or has no slash
+ */
+function firstPathSegment(path: string | undefined): string | undefined {
+  if (!path) {
+    return undefined
+  }
+
+  const firstSlashIndex = path.indexOf('/')
+  if (firstSlashIndex === -1) {
+    return undefined
+  }
+  return path.slice(0, firstSlashIndex)
+}
+
+/**
+ * Check whether an IAM role ARN represents the role for an assumed-role session ARN.
+ *
+ * @param roleArn the IAM role ARN to compare
+ * @param sessionArn the assumed-role session ARN to compare
+ * @returns true if the role ARN and session ARN have the same partition, account, and role name
+ */
+function roleArnMatchesAssumedRoleSession(roleArn: string, sessionArn: string): boolean {
+  if (!isIamRoleArn(roleArn) || !isAssumedRoleArn(sessionArn)) {
+    return false
+  }
+
+  const roleArnParts = splitArnParts(roleArn)
+  const sessionArnParts = splitArnParts(sessionArn)
+  if (
+    roleArnParts.partition !== sessionArnParts.partition ||
+    roleArnParts.accountId !== sessionArnParts.accountId
+  ) {
+    return false
+  }
+
+  const roleName = lastPathSegment(roleArnParts.resourcePath)
+  const sessionRoleName = firstPathSegment(sessionArnParts.resourcePath)
+  if (!roleName || !sessionRoleName) {
+    return false
+  }
+
+  return roleName.localeCompare(sessionRoleName, 'en', { sensitivity: 'base' }) === 0
 }
 
 /**


### PR DESCRIPTION
## Summary
- match IAM role principals with paths to assumed-role session principals by partition, account, and role name
- preserve a single matching path for pathed and unpathed role principals
- report the matched policy role ARN, including its path, in principal explains

## Tests
- `npx vitest --run src/principal/principal.test.ts`
- `npm run build`
- `npm test`
- `npm run format-check`

## Notes
- Added sanitized reproduction coverage for pathed roles, case-insensitive role-name matching, different role names, and different accounts.