### PR TITLE
fix: update dependency action reference

### DIFF
--- a/.github/workflows/update-dependencies.yml
+++ b/.github/workflows/update-dependencies.yml
@@ -14,7 +14,7 @@ jobs:
       actions: write # Run check workflows
     steps:
       - name: Run dependency update
-        uses: cloud-copilot/action-update-dependencies@fe48d42724df9c4ed34abf9c0cc97a8da42917f4
+        uses: cloud-copilot/action-update-dependencies@c5c47ad399628ae464f31d1068717bcb39cf6002
         with:
           check-workflow: pr-checks.yml
           post-merge-workflow: release.yml


### PR DESCRIPTION
## Summary
- update the scheduled dependency workflow to use the action-update-dependencies commit that runs formatting after dependency updates

## Validation
- verified the workflow references the merged action commit SHA

## Context
This should prevent dependency update PRs from failing format checks when a formatter dependency changes output.