### PR TITLE
fix: match pathed role requests to session principals

### DIFF
--- a/src/core_engine/coreEngineTests/discoveryMode/roleVsSession.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/roleVsSession.json
@@ -33,6 +33,72 @@
     }
   },
   {
+    "name": "Allow pathed role when session is allowed by resource policy",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::mybucket/testobject",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:role/team/test-role",
+      "context": {}
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::mybucket/testobject",
+          "Principal": {
+            "AWS": "arn:aws:sts::123456789012:assumed-role/test-role/session-name"
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredRoleSessionName": true
+    }
+  },
+  {
+    "name": "Allow role with multiple path levels when session is allowed by resource policy",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::mybucket/testobject",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:role/org/team/test-role",
+      "context": {}
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::mybucket/testobject",
+          "Principal": {
+            "AWS": "arn:aws:sts::123456789012:assumed-role/test-role/session-name"
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredRoleSessionName": true
+    }
+  },
+  {
     "name": "Allow Differently Named Session When Resource Policy Allows for Session",
     "request": {
       "action": "s3:GetObject",

--- a/src/principal/principal.test.ts
+++ b/src/principal/principal.test.ts
@@ -736,14 +736,14 @@ describe('requestMatchesPrincipalStatement', () => {
 
   describe('Discovery simulationMode - session ARN in policy, role ARN in request', () => {
     it('should return Match and ignoredRoleSessionName when requested role matches policy assumed role session', () => {
-      // Given a policy with an assumed-role session ARN principal
+      //Given a policy with an assumed-role session ARN principal
       const policy = loadPolicy({
         Statement: [
           { Principal: { AWS: 'arn:aws:sts::555555555555:assumed-role/role-name/session-a' } }
         ]
       })
       const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
-      // And a request with the matching role ARN
+      //And a request with the matching role ARN
       const request = new AwsRequestImpl(
         'arn:aws:iam::555555555555:role/role-name',
         defaultResource,
@@ -751,7 +751,7 @@ describe('requestMatchesPrincipalStatement', () => {
         new RequestContextImpl({})
       )
 
-      // When we check if the request matches the principal statement
+      //When we check if the request matches the principal statement
       const result = requestMatchesPrincipalStatement(
         request,
         principalStatement,
@@ -759,7 +759,65 @@ describe('requestMatchesPrincipalStatement', () => {
         'Allow'
       )
 
-      // Then it should return Match and ignoredRoleSessionName true
+      //Then it should return Match and ignoredRoleSessionName true
+      expect(result.explain.matches).toBe('Match')
+      expect(result.ignoredRoleSessionName).toBe(true)
+    })
+
+    it('should return Match and ignoredRoleSessionName when requested role with path matches policy assumed role session', () => {
+      //Given a policy with an assumed-role session ARN principal
+      const policy = loadPolicy({
+        Statement: [
+          { Principal: { AWS: 'arn:aws:sts::555555555555:assumed-role/role-name/session-a' } }
+        ]
+      })
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+      //And a request with the matching role ARN under a path
+      const request = new AwsRequestImpl(
+        'arn:aws:iam::555555555555:role/team/role-name',
+        defaultResource,
+        's3:GetBucket',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        discoverySimulationParameters,
+        'Allow'
+      )
+
+      //Then it should return Match and ignoredRoleSessionName true
+      expect(result.explain.matches).toBe('Match')
+      expect(result.ignoredRoleSessionName).toBe(true)
+    })
+
+    it('should return Match and ignoredRoleSessionName when requested role with multiple path levels matches policy assumed role session', () => {
+      //Given a policy with an assumed-role session ARN principal
+      const policy = loadPolicy({
+        Statement: [
+          { Principal: { AWS: 'arn:aws:sts::555555555555:assumed-role/role-name/session-a' } }
+        ]
+      })
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+      //And a request with the matching role ARN under multiple path levels
+      const request = new AwsRequestImpl(
+        'arn:aws:iam::555555555555:role/org/team/role-name',
+        defaultResource,
+        's3:GetBucket',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        discoverySimulationParameters,
+        'Allow'
+      )
+
+      //Then it should return Match and ignoredRoleSessionName true
       expect(result.explain.matches).toBe('Match')
       expect(result.ignoredRoleSessionName).toBe(true)
     })

--- a/src/principal/principal.ts
+++ b/src/principal/principal.ts
@@ -307,13 +307,19 @@ export function requestMatchesPrincipalStatement(
       simulationParameters.simulationMode === 'Discovery' &&
       isAssumedRoleArn(principalStatement.arn())
     ) {
-      const principalRoleArn = convertAssumedRoleArnToRoleArn(principalStatement.arn())
-      let requestRoleArn = request.principal.value()
-      if (isAssumedRoleArn(requestRoleArn)) {
-        requestRoleArn = convertAssumedRoleArnToRoleArn(requestRoleArn)
+      const requestRoleArn = request.principal.value()
+      let roleMatchesSession = false
+      if (isIamRoleArn(requestRoleArn)) {
+        roleMatchesSession = roleArnMatchesAssumedRoleSession(
+          requestRoleArn,
+          principalStatement.arn()
+        )
+      } else if (isAssumedRoleArn(requestRoleArn)) {
+        const principalRoleArn = convertAssumedRoleArnToRoleArn(principalStatement.arn())
+        roleMatchesSession = principalRoleArn === convertAssumedRoleArnToRoleArn(requestRoleArn)
       }
 
-      if (principalRoleArn === requestRoleArn) {
+      if (roleMatchesSession) {
         const discoveryMatch = allowOrDeny === 'Allow' ? 'Match' : 'NoMatch'
         return {
           explain: {


### PR DESCRIPTION
## Summary
- Match IAM role ARNs with paths to STS assumed-role session principals in Discovery mode
- Add unit coverage for session principals matching unpathed, single-path, and multi-path role ARN requests
- Add core engine JSON scenarios for pathed role requests matching session principals

## Tests
- npx vitest --run src/principal/principal.test.ts -t "Discovery simulationMode - session ARN in policy, role ARN in request"
- npx vitest --run src/principal/principal.test.ts
- npx vitest --run src/core_engine/coreSimulatorEngine.test.ts
- npm run build
- npm run format-check
- npm test

## Risks
- Narrowly scoped to Discovery-mode matching where the policy principal is an assumed-role session ARN.