### PR TITLE
fix: evaluate scp notresource resource org conditions

### DIFF
--- a/src/core_engine/coreEngineTests/scps.json
+++ b/src/core_engine/coreEngineTests/scps.json
@@ -340,5 +340,396 @@
       "response": "ExplicitlyDenied",
       "blockedBy": ["scp"]
     }
+  },
+  {
+    "name": "SCP Deny with NotResource and StringNotEqualsIfExists does not deny when ResourceOrgID matches",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/example-object.txt",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:ResourceOrgID": "o-exampleorg"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::example-bucket/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:iam::aws:policy/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "SCP Deny with NotResource and StringNotEqualsIfExists denies when ResourceOrgID differs",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/example-object.txt",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:ResourceOrgID": "o-otherorg"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::example-bucket/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:iam::aws:policy/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ExplicitlyDenied",
+      "blockedBy": ["scp"]
+    }
+  },
+  {
+    "name": "SCP Deny with NotResource and StringNotEqualsIfExists denies when ResourceOrgID is missing",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/example-object.txt",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::example-bucket/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:iam::aws:policy/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ExplicitlyDenied",
+      "blockedBy": ["scp"]
+    }
+  },
+  {
+    "name": "SCP Deny with NotResource and StringNotEqualsIfExists does not deny excluded IAM policy when ResourceOrgID differs",
+    "request": {
+      "action": "iam:GetPolicy",
+      "resource": {
+        "resource": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:ResourceOrgID": "o-otherorg"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "iam:GetPolicy",
+            "Resource": "arn:aws:iam::aws:policy/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:iam::aws:policy/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "SCP Deny with NotResource and StringNotEqualsIfExists does not deny excluded IAM policy when ResourceOrgID is missing",
+    "request": {
+      "action": "iam:GetPolicy",
+      "resource": {
+        "resource": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "iam:GetPolicy",
+            "Resource": "arn:aws:iam::aws:policy/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:iam::aws:policy/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "SCP Deny with multiple NotResources does not deny when one NotResource matches",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/example-object.txt",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:ResourceOrgID": "o-otherorg"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::example-bucket/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:iam::aws:policy/*", "arn:aws:s3:::example-bucket/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "SCP Deny with same-service NotResource and StringNotEqualsIfExists denies when resource differs",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket/example-object.txt",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:ResourceOrgID": "o-otherorg"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::example-bucket/*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-example",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "*",
+                "NotResource": ["arn:aws:s3:::allowed-bucket/*"],
+                "Condition": {
+                  "StringNotEqualsIfExists": {
+                    "aws:ResourceOrgID": "o-exampleorg"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ExplicitlyDenied",
+      "blockedBy": ["scp"]
+    }
   }
 ]

--- a/src/explain/statementExplain.ts
+++ b/src/explain/statementExplain.ts
@@ -10,10 +10,45 @@ export interface ActionExplain {
   matches: boolean
 }
 
+/**
+ * Known reasons that a policy resource can fail to match a request resource.
+ *
+ * The `invertible` flag records whether the mismatch definitively proves that
+ * the request is outside a `NotResource` set. Non-invertible reasons indicate
+ * invalid policy syntax or unavailable input rather than a definitive mismatch.
+ */
+export const resourceMismatchReasons = {
+  invalidPolicyResourceArn: { invertible: false },
+  requestMissingResource: { invertible: false },
+  unresolvablePolicyVariable: { invertible: false },
+  shortArnNoMatch: { invertible: true },
+  // Expanded short ARN mismatches preserve existing conservative behavior and are not inverted.
+  shortArnExpandedMismatch: { invertible: false },
+  wildcardOnlyActionSpecificResource: { invertible: true },
+  requestAllResourcesSpecificNotResource: { invertible: true },
+  requestAllResourcesDenySpecificResource: { invertible: true },
+  resourcePatternMismatch: { invertible: true },
+  partitionMismatch: { invertible: true },
+  serviceMismatch: { invertible: true },
+  regionMismatch: { invertible: true },
+  accountMismatch: { invertible: true },
+  productMismatch: { invertible: true },
+  resourceIdMismatch: { invertible: true }
+} as const
+
+/**
+ * A machine-readable key explaining why a policy resource did not match a request resource.
+ */
+export type ResourceMismatchReason = keyof typeof resourceMismatchReasons
+
 export interface ResourceExplain {
   resource: string
   resolvedValue?: string
   errors?: string[]
+  /**
+   * Machine-readable reason for a non-match, when the resource did not match.
+   */
+  mismatchReason?: ResourceMismatchReason
   matches: boolean
 }
 

--- a/src/resource/resource.test.ts
+++ b/src/resource/resource.test.ts
@@ -128,7 +128,8 @@ const resourceTests: ResourceTest[] = [
       {
         resource: 'arn:aws:s3:::my_corporate_bucket',
         matches: false,
-        errors: ['Service does not match']
+        errors: ['Service does not match'],
+        mismatchReason: 'serviceMismatch'
       }
     ]
   },
@@ -1893,6 +1894,11 @@ function validateExplains(expected: ResourceExplain[], actual: ResourceExplain[]
     } else {
       expect(found?.errors, `${explain.resource} errors`).toBeUndefined()
     }
+    if (explain.mismatchReason) {
+      expect(found?.mismatchReason, `${explain.resource} mismatch reason`).toBe(
+        explain.mismatchReason
+      )
+    }
   }
 }
 
@@ -2021,6 +2027,23 @@ const notResourceTests: ResourceTest[] = [
       },
       {
         resource: 'arn:aws:s3:::different_bucket',
+        matches: true
+      }
+    ]
+  },
+  {
+    name: 'SCP Deny NotResource should match a request for a different service full ARN',
+    policyType: 'scp',
+    effect: 'Deny',
+    notResourceStatements: ['arn:aws:iam::aws:policy/*'],
+    resource: {
+      resource: 'arn:aws:s3:::example-bucket/example-object.txt',
+      accountId: '123456789012'
+    },
+    expectMatch: true,
+    explains: [
+      {
+        resource: 'arn:aws:iam::aws:policy/*',
         matches: true
       }
     ]

--- a/src/resource/resource.ts
+++ b/src/resource/resource.ts
@@ -1,5 +1,9 @@
 import { type Resource, type Statement } from '@cloud-copilot/iam-policy'
-import { type ResourceExplain, type StatementExplain } from '../explain/statementExplain.js'
+import {
+  type ResourceExplain,
+  resourceMismatchReasons,
+  type StatementExplain
+} from '../explain/statementExplain.js'
 import { type PolicyType } from '../policyType.js'
 import { type AwsRequest } from '../request/request.js'
 import { convertIamString, getResourceSegments } from '../util.js'
@@ -198,13 +202,36 @@ export function requestMatchesNotResources(
       effect,
       policyType
     )
-    if (!explain.errors) {
+    if (shouldInvertNotResourceExplain(explain)) {
       explain.matches = !explain.matches
+      delete explain.errors
+      delete explain.mismatchReason
     }
     return explain
   })
   const matches = !explains.some((explain) => !explain.matches)
   return { matches, explains }
+}
+
+/**
+ * Determine whether a Resource match explain can be inverted for NotResource matching.
+ *
+ * The resource mismatch reason registry owns the decision about which mismatches
+ * definitively prove the request is outside the NotResource set and can be inverted.
+ *
+ * @param explain the Resource matching explain to inspect
+ * @returns true when the explain should be inverted for NotResource semantics
+ */
+function shouldInvertNotResourceExplain(explain: ResourceExplain): boolean {
+  if (explain.matches) {
+    return true
+  }
+
+  if (!explain.mismatchReason) {
+    throw new Error(`Non-matching resource explain is missing mismatchReason: ${explain.resource}`)
+  }
+
+  return resourceMismatchReasons[explain.mismatchReason].invertible
 }
 
 /*
@@ -283,14 +310,16 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Policy resource ARN is not valid for this policy type']
+        errors: ['Policy resource ARN is not valid for this policy type'],
+        mismatchReason: 'invalidPolicyResourceArn'
       }
     }
 
     if (behavior === 'noMatch') {
       return {
         resource: policyResource.value(),
-        matches: false
+        matches: false,
+        mismatchReason: 'shortArnNoMatch'
       }
     }
 
@@ -308,6 +337,9 @@ function singleResourceMatchesRequest(
     )
     // Preserve the original (unexpanded) resource value in the explain
     result.resource = policyResource.value()
+    if (!result.matches && result.mismatchReason) {
+      result.mismatchReason = 'shortArnExpandedMismatch'
+    }
     return result
   }
 
@@ -318,7 +350,8 @@ function singleResourceMatchesRequest(
     if (request.wildcardOnlyAction) {
       return {
         resource: policyResource.value(),
-        matches: false
+        matches: false,
+        mismatchReason: 'wildcardOnlyActionSpecificResource'
       }
     }
 
@@ -330,13 +363,15 @@ function singleResourceMatchesRequest(
     } else if (effect === 'Allow' && resourceType === 'NotResource') {
       return {
         resource: policyResource.value(),
-        matches: false // This gets inverted in the caller
+        matches: false, // This gets inverted in the caller
+        mismatchReason: 'requestAllResourcesSpecificNotResource'
       }
     } else if (effect === 'Deny' && resourceType === 'Resource') {
       // This is a Deny statement that is not all resources, so it's not a match
       return {
         resource: policyResource.value(),
-        matches: false
+        matches: false,
+        mismatchReason: 'requestAllResourcesDenySpecificResource'
       }
     } else if (effect === 'Deny' && resourceType === 'NotResource') {
       return {
@@ -368,7 +403,8 @@ function singleResourceMatchesRequest(
       if (overlaps.some((o) => o === 'none' || o === 'policy_is_subset')) {
         return {
           resource: policyResource.value(),
-          matches: false
+          matches: false,
+          mismatchReason: 'resourcePatternMismatch'
         }
       }
     } else if (resourceType === 'NotResource' && effect === 'Allow') {
@@ -389,7 +425,8 @@ function singleResourceMatchesRequest(
         return {
           resource: policyResource.value(),
           // This gets inverted in the caller
-          matches: false
+          matches: false,
+          mismatchReason: 'resourcePatternMismatch'
         }
       }
     } else if (resourceType === 'NotResource' && effect === 'Deny') {
@@ -404,7 +441,8 @@ function singleResourceMatchesRequest(
         return {
           resource: policyResource.value(),
           // This gets inverted in the caller
-          matches: false
+          matches: false,
+          mismatchReason: 'resourcePatternMismatch'
         }
       } else {
         return {
@@ -423,7 +461,8 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Request does not have a resource']
+        errors: ['Request does not have a resource'],
+        mismatchReason: 'requestMissingResource'
       }
     }
 
@@ -432,7 +471,8 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Partition does not match']
+        errors: ['Partition does not match'],
+        mismatchReason: 'partitionMismatch'
       }
     }
 
@@ -440,7 +480,8 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Service does not match']
+        errors: ['Service does not match'],
+        mismatchReason: 'serviceMismatch'
       }
     }
 
@@ -448,7 +489,8 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Region does not match']
+        errors: ['Region does not match'],
+        mismatchReason: 'regionMismatch'
       }
     }
 
@@ -456,7 +498,8 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Account does not match']
+        errors: ['Account does not match'],
+        mismatchReason: 'accountMismatch'
       }
     }
 
@@ -466,7 +509,8 @@ function singleResourceMatchesRequest(
       return {
         resource: policyResource.value(),
         matches: false,
-        errors: ['Product does not match']
+        errors: ['Product does not match'],
+        mismatchReason: 'productMismatch'
       }
     }
 
@@ -482,10 +526,12 @@ function singleResourceMatchesRequest(
     const resolvedValue = resolvedResource === policyResource.value() ? undefined : resolvedResource
 
     if (!pattern.test(requestResourceId)) {
+      const mismatchReason = errors?.length ? 'unresolvablePolicyVariable' : 'resourceIdMismatch'
       return {
         resource: policyResource.value(),
         matches: false,
         errors,
+        mismatchReason,
         resolvedValue
       }
     }


### PR DESCRIPTION
## Summary
- fix NotResource evaluation so definitive resource mismatches are inverted based on typed mismatch reasons instead of error strings
- add explicit resource mismatch reason metadata with invertibility decisions
- add SCP core engine coverage for ResourceOrgID equal, different, missing, excluded IAM policy resources, multi-entry NotResource, and same-service mismatch cases

## Tests
- npm run build
- npx vitest --run src/resource/resource.test.ts src/core_engine/coreSimulatorEngine.test.ts
- npx vitest --run src/core_engine/coreSimulatorEngine.test.ts
- npm test
- npm run format-check

## Risks / Follow-ups
- `mismatchReason` is an optional addition to exported `ResourceExplain`; existing callers should remain compatible.
- Future resource non-match paths should add a reason to `resourceMismatchReasons` and explicitly choose invertibility.