### PR TITLE
feat: add anonymous request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,42 @@ It will also return "explains" for each statement that was evaluated, detailing 
 - Session Policies
 - Validation of Global Condition Keys for each action
 - Automatically populating context keys from the request such as `aws:PrincipalServiceName`
-- Support for anonymous requests
+
+### Anonymous Requests
+
+Use `anonymousPrincipal` to simulate unsigned requests, such as public S3 object access granted by a bucket policy. Anonymous requests do not have identity policies, session policies, permission boundaries, or SCPs; those principal-side policy inputs are rejected by `runSimulation`.
+
+```typescript
+import { anonymousPrincipal, runSimulation, type Simulation } from '@cloud-copilot/iam-simulate'
+
+const simulation: Simulation = {
+  request: {
+    principal: anonymousPrincipal,
+    action: 's3:GetObject',
+    resource: {
+      resource: 'arn:aws:s3:::public-bucket/file.txt',
+      accountId: '123456789012'
+    },
+    contextVariables: {}
+  },
+  identityPolicies: [],
+  serviceControlPolicies: [],
+  resourceControlPolicies: [],
+  resourcePolicy: {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: '*',
+        Action: 's3:GetObject',
+        Resource: 'arn:aws:s3:::public-bucket/*'
+      }
+    ]
+  }
+}
+
+const response = await runSimulation(simulation, {})
+```
 
 ## Installation
 

--- a/src/core_engine/coreEngineTests/anonymous.json
+++ b/src/core_engine/coreEngineTests/anonymous.json
@@ -1,0 +1,352 @@
+[
+  {
+    "name": "anonymous implicit deny without resource policy or RCP",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "expected": { "response": "ImplicitlyDenied" }
+  },
+  {
+    "name": "anonymous allowed by public resource policy without RCP",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "Allowed" }
+  },
+  {
+    "name": "anonymous allowed by public resource policy with default RCP",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [{ "orgIdentifier": "o-123", "policies": [] }],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "Allowed" }
+  },
+  {
+    "name": "anonymous blocked by RCP deny",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [
+      {
+        "orgIdentifier": "o-123",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Deny",
+                "Principal": "*",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::public-bucket/*"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "ExplicitlyDenied", "blockedBy": ["rcp"] }
+  },
+  {
+    "name": "anonymous ignores SCP explicit deny",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "o-123",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Deny",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::public-bucket/*"
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "Allowed" }
+  },
+  {
+    "name": "anonymous denied when resource policy allows only specific principal",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "ImplicitlyDenied" }
+  },
+  {
+    "name": "anonymous denied when resource policy allows only account principal",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": { "AWS": "arn:aws:iam::123456789012:root" },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "ImplicitlyDenied" }
+  },
+  {
+    "name": "anonymous denied when resource policy allows only service principal",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": { "Service": "ec2.amazonaws.com" },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "ImplicitlyDenied" }
+  },
+  {
+    "name": "anonymous allowed by not principal excluding signed principal",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "NotPrincipal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "Allowed" }
+  },
+  {
+    "name": "anonymous denied by wildcard not principal",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "NotPrincipal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*"
+        }
+      ]
+    },
+    "expected": { "response": "ImplicitlyDenied" }
+  },
+  {
+    "name": "anonymous condition key must match when present in resource policy",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": { "aws:SecureTransport": "true" }
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*",
+          "Condition": { "Bool": { "aws:SecureTransport": "true" } }
+        }
+      ]
+    },
+    "expected": { "response": "Allowed" }
+  },
+  {
+    "name": "anonymous condition key missing prevents resource policy allow",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*",
+          "Condition": { "Bool": { "aws:SecureTransport": "true" } }
+        }
+      ]
+    },
+    "expected": { "response": "ImplicitlyDenied" }
+  },
+  {
+    "name": "anonymous discovery mode only ignores conditions from supplied constraints",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
+      "principal": { "type": "Anonymous" },
+      "context": {}
+    },
+    "identityPolicies": [],
+    "serviceControlPolicies": [],
+    "resourceControlPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": "*",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::public-bucket/*",
+          "Condition": { "Bool": { "aws:SecureTransport": "true" } }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery",
+      "discoveryContextKeyConstraints": [
+        { "keyName": "aws:SecureTransport", "presenceIsKnown": false, "valueIsKnown": false }
+      ]
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "resource": {
+          "allow": [{ "op": "Bool", "key": "aws:SecureTransport", "values": ["true"] }]
+        }
+      }
+    }
+  }
+]

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,10 +31,15 @@ export type {
   StatementExplain
 } from './explain/statementExplain.js'
 export { allowedContextKeysForRequest } from './simulation_engine/contextKeys.js'
-export type {
-  Simulation,
-  SimulationIdentityPolicy,
-  SimulationOrgPolicies
+export {
+  anonymousPrincipal,
+  isAnonymousRequestPrincipal,
+  isSimulationRequestPrincipal,
+  type AnonymousRequestPrincipal,
+  type Simulation,
+  type SimulationIdentityPolicy,
+  type SimulationOrgPolicies,
+  type SimulationRequestPrincipal
 } from './simulation_engine/simulation.js'
 export { runSimulation } from './simulation_engine/simulationEngine.js'
 export type {

--- a/src/principal/principal.test.ts
+++ b/src/principal/principal.test.ts
@@ -52,6 +52,133 @@ describe('userArnFromFederatedUserArn', () => {
 })
 
 describe('requestMatchesPrincipalStatement', () => {
+  describe('anonymous principal', () => {
+    it('should return Match for wildcard principal', () => {
+      //Given a wildcard policy principal statement
+      const policy = loadPolicy({
+        Statement: [{ Principal: '*' }]
+      })
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+      const request = new AwsRequestImpl(
+        { type: 'Anonymous' },
+        defaultResource,
+        's3:GetObject',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then the anonymous request matches the wildcard principal
+      expect(result.explain.matches).toEqual('Match')
+    })
+
+    it('should return NoMatch for specific AWS principal', () => {
+      //Given a specific AWS policy principal statement
+      const policy = loadPolicy({
+        Statement: [{ Principal: { AWS: 'arn:aws:iam::123456789012:user/Alice' } }]
+      })
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+      const request = new AwsRequestImpl(
+        { type: 'Anonymous' },
+        defaultResource,
+        's3:GetObject',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then the anonymous request does not match the specific principal
+      expect(result.explain.matches).toEqual('NoMatch')
+    })
+
+    it('should return NoMatch for account principal', () => {
+      //Given an account policy principal statement
+      const policy = loadPolicy({
+        Statement: [{ Principal: { AWS: '123456789012' } }]
+      })
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+      const request = new AwsRequestImpl(
+        { type: 'Anonymous' },
+        defaultResource,
+        's3:GetObject',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then the anonymous request does not match an account principal
+      expect(result.explain.matches).toEqual('NoMatch')
+    })
+
+    it('should return NoMatch for service principal', () => {
+      //Given a service policy principal statement
+      const policy = loadPolicy({
+        Statement: [{ Principal: { Service: 'anonymous' } }]
+      })
+      const principalStatement = (policy.statements()[0] as PrincipalStatement).principals()[0]
+      const request = new AwsRequestImpl(
+        { type: 'Anonymous' },
+        defaultResource,
+        's3:GetObject',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the principal statement
+      const result = requestMatchesPrincipalStatement(
+        request,
+        principalStatement,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then the anonymous display value is not used for service-principal matching
+      expect(result.explain.matches).toEqual('NoMatch')
+    })
+
+    it('should return NoMatch for wildcard NotPrincipal', () => {
+      //Given a wildcard NotPrincipal statement
+      const policy = loadPolicy({
+        Statement: [{ NotPrincipal: '*' }]
+      })
+      const notPrincipals = (policy.statements()[0] as NotPrincipalStatement).notPrincipals()
+      const request = new AwsRequestImpl(
+        { type: 'Anonymous' },
+        defaultResource,
+        's3:GetObject',
+        new RequestContextImpl({})
+      )
+
+      //When we check if the request matches the NotPrincipal statement
+      const result = requestMatchesNotPrincipal(
+        request,
+        notPrincipals,
+        defaultSimulationParameters,
+        'Allow'
+      )
+
+      //Then the anonymous request is excluded by wildcard NotPrincipal
+      expect(result.matches).toEqual('NoMatch')
+    })
+  })
+
   describe('service principal', () => {
     it('should return Match for matching service principal', () => {
       //Given a policy principal statement

--- a/src/principal/principal.ts
+++ b/src/principal/principal.ts
@@ -9,6 +9,7 @@ import {
 import { type SimulationParameters } from '../core_engine/CoreSimulatorEngine.js'
 import { type PrincipalExplain, type StatementExplain } from '../explain/statementExplain.js'
 import { type AwsRequest } from '../request/request.js'
+import { assertAuthenticatedRequestPrincipal } from '../request/requestPrincipal.js'
 
 interface PrincipalAnalysis {
   explain: PrincipalExplain
@@ -177,8 +178,19 @@ export function requestMatchesPrincipalStatement(
   simulationParameters: SimulationParameters,
   allowOrDeny: 'Allow' | 'Deny'
 ): PrincipalAnalysis {
+  const requestPrincipal = request.principal
+  if (requestPrincipal.isAnonymous()) {
+    return {
+      explain: {
+        matches: principalStatement.isWildcardPrincipal() ? 'Match' : 'NoMatch',
+        principal: principalStatement.value()
+      }
+    }
+  }
+  assertAuthenticatedRequestPrincipal(requestPrincipal)
+
   if (principalStatement.isServicePrincipal()) {
-    if (principalStatement.service() === request.principal.value()) {
+    if (principalStatement.service() === requestPrincipal.value()) {
       return {
         explain: {
           matches: 'Match',
@@ -195,7 +207,7 @@ export function requestMatchesPrincipalStatement(
   }
 
   if (principalStatement.isCanonicalUserPrincipal()) {
-    if (principalStatement.canonicalUser() === request.principal.value()) {
+    if (principalStatement.canonicalUser() === requestPrincipal.value()) {
       return {
         explain: {
           matches: 'Match',
@@ -212,7 +224,7 @@ export function requestMatchesPrincipalStatement(
   }
 
   if (principalStatement.isFederatedPrincipal()) {
-    if (principalStatement.federated() === request.principal.value()) {
+    if (principalStatement.federated() === requestPrincipal.value()) {
       return {
         explain: {
           matches: 'Match',
@@ -238,7 +250,7 @@ export function requestMatchesPrincipalStatement(
   }
 
   if (principalStatement.isAccountPrincipal()) {
-    if (principalStatement.accountId() === request.principal.accountId()) {
+    if (principalStatement.accountId() === requestPrincipal.accountId()) {
       return {
         explain: {
           matches: 'AccountLevelMatch',
@@ -255,8 +267,8 @@ export function requestMatchesPrincipalStatement(
   }
 
   if (principalStatement.isAwsPrincipal()) {
-    if (isAssumedRoleArn(request.principal.value())) {
-      const sessionArn = request.principal.value()
+    if (isAssumedRoleArn(requestPrincipal.value())) {
+      const sessionArn = requestPrincipal.value()
       if (roleArnMatchesAssumedRoleSession(principalStatement.arn(), sessionArn)) {
         return {
           explain: {
@@ -266,8 +278,8 @@ export function requestMatchesPrincipalStatement(
           }
         }
       }
-    } else if (isFederatedUserArn(request.principal.value())) {
-      const sessionArn = request.principal.value()
+    } else if (isFederatedUserArn(requestPrincipal.value())) {
+      const sessionArn = requestPrincipal.value()
       const userArn = userArnFromFederatedUserArn(sessionArn)
       if (principalStatement.arn() === userArn) {
         return {
@@ -280,7 +292,7 @@ export function requestMatchesPrincipalStatement(
       }
     }
 
-    if (principalStatement.arn() === request.principal.value()) {
+    if (principalStatement.arn() === requestPrincipal.value()) {
       return {
         explain: {
           matches: 'Match',
@@ -303,7 +315,7 @@ export function requestMatchesPrincipalStatement(
       simulationParameters.simulationMode === 'Discovery' &&
       isAssumedRoleArn(principalStatement.arn())
     ) {
-      const requestRoleArn = request.principal.value()
+      const requestRoleArn = requestPrincipal.value()
       let roleMatchesSession = false
       if (isIamRoleArn(requestRoleArn)) {
         roleMatchesSession = roleArnMatchesAssumedRoleSession(

--- a/src/request/request.ts
+++ b/src/request/request.ts
@@ -1,6 +1,7 @@
 import { type ContextKey, type RequestContext } from '../requestContext.js'
+import { type SimulationRequestPrincipal } from '../simulation_engine/simulation.js'
 import { type RequestAction, RequestActionImpl } from './requestAction.js'
-import { type RequestPrincipal, RequestPrincipalImpl } from './requestPrincipal.js'
+import { requestPrincipalFromInput, type RequestPrincipal } from './requestPrincipal.js'
 import { type RequestResource, ResourceRequestImpl } from './requestResource.js'
 
 /**
@@ -52,15 +53,17 @@ export interface AwsRequest {
 
 export class AwsRequestImpl implements AwsRequest {
   public readonly wildcardOnlyAction: boolean
+  private readonly requestPrincipal: RequestPrincipal
 
   constructor(
-    public readonly principalString: string,
+    public readonly principalInput: SimulationRequestPrincipal,
     public readonly resourceIdentifier: { resource: string; accountId: string },
     public readonly actionString: string,
     public readonly context: RequestContext,
     wildcardOnlyAction?: boolean
   ) {
     this.wildcardOnlyAction = wildcardOnlyAction ?? false
+    this.requestPrincipal = requestPrincipalFromInput(this.principalInput)
   }
 
   get action(): RequestAction {
@@ -75,7 +78,7 @@ export class AwsRequestImpl implements AwsRequest {
   }
 
   get principal(): RequestPrincipal {
-    return new RequestPrincipalImpl(this.principalString)
+    return this.requestPrincipal
   }
 
   public contextKeyExists(key: string): boolean {

--- a/src/request/requestPrincipal.test.ts
+++ b/src/request/requestPrincipal.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import { anonymousPrincipal } from '../simulation_engine/simulation.js'
+import { requestPrincipalFromInput } from './requestPrincipal.js'
+
+describe('requestPrincipalFromInput', () => {
+  it('creates an anonymous request principal', () => {
+    //Given an anonymous principal input
+    const principalInput = anonymousPrincipal
+
+    //When the request principal is created
+    const principal = requestPrincipalFromInput(principalInput)
+
+    //Then it represents an anonymous request
+    expect(principal.kind()).toEqual('Anonymous')
+    expect(principal.isAnonymous()).toEqual(true)
+    expect('accountId' in principal).toEqual(false)
+    expect('value' in principal).toEqual(false)
+  })
+
+  it('creates a string request principal with an account id for ARN values', () => {
+    //Given an ARN principal input
+    const principalInput = 'arn:aws:iam::123456789012:user/Alice'
+
+    //When the request principal is created
+    const principal = requestPrincipalFromInput(principalInput)
+
+    //Then it represents the string principal
+    expect(principal.kind()).toEqual('Authenticated')
+    expect(principal.isAnonymous()).toEqual(false)
+    expect(principal.accountId()).toEqual('123456789012')
+    expect(principal.value()).toEqual(principalInput)
+  })
+
+  it('returns undefined account id for non-ARN string values', () => {
+    //Given a non-ARN principal input
+    const principalInput = 'not-an-arn'
+
+    //When the request principal is created
+    const principal = requestPrincipalFromInput(principalInput)
+
+    //Then no account id is parsed
+    expect(principal.accountId()).toBeUndefined()
+  })
+
+  it('throws a clear error for malformed object principals', () => {
+    //Given a malformed principal input
+    const principalInput = { type: 'User' }
+
+    //When the request principal is created
+    const createPrincipal = () => requestPrincipalFromInput(principalInput as any)
+
+    //Then a clear validation error is thrown
+    expect(createPrincipal).toThrow('invalid.principal')
+  })
+
+  it('throws a clear error for anonymous principals with extra fields', () => {
+    //Given an anonymous principal input with extra fields
+    const principalInput = { type: 'Anonymous', accountId: '123456789012' }
+
+    //When the request principal is created
+    const createPrincipal = () => requestPrincipalFromInput(principalInput as any)
+
+    //Then a clear validation error is thrown
+    expect(createPrincipal).toThrow('invalid.principal')
+  })
+})

--- a/src/request/requestPrincipal.ts
+++ b/src/request/requestPrincipal.ts
@@ -1,28 +1,150 @@
+import {
+  isAnonymousRequestPrincipal,
+  isSimulationRequestPrincipal,
+  type SimulationRequestPrincipal
+} from '../simulation_engine/simulation.js'
+
+export type RequestPrincipalKind = 'Authenticated' | 'Anonymous'
+
 /**
- * A principal in a request
+ * Common request-principal behavior shared by anonymous and authenticated requests.
  */
 export interface RequestPrincipal {
   /**
-   * The raw string of the principal
+   * The kind of request principal being simulated.
+   *
+   * @returns the request principal kind.
+   */
+  kind(): RequestPrincipalKind
+
+  /**
+   * Whether the request principal represents an unsigned anonymous request.
+   *
+   * @returns true if this is an anonymous request principal.
+   */
+  isAnonymous(): this is AnonymousRequestPrincipal
+
+  /**
+   * Whether the request principal is an authenticated principal request
+   */
+  isAuthenticated(): this is AuthenticatedRequestPrincipal
+}
+
+/**
+ * An unsigned anonymous request principal.
+ */
+export interface AnonymousRequestPrincipal extends RequestPrincipal {
+  kind(): 'Anonymous'
+}
+
+/**
+ * An authenticated request principal represented by a concrete principal string.
+ */
+export interface AuthenticatedRequestPrincipal extends RequestPrincipal {
+  kind(): 'Authenticated'
+
+  /**
+   * The raw string of the authenticated principal.
+   *
+   * @returns the principal string.
    */
   value(): string
 
   /**
-   * The account id of the principal, if the principal is an ARN that has an account ID, otherwise undefined
+   * The account id of the principal, if the principal is an ARN that has an account ID, otherwise undefined.
+   *
+   * @returns the principal account ID, if available.
    */
   accountId(): string | undefined
 }
 
-export class RequestPrincipalImpl implements RequestPrincipal {
+/**
+ * Checks whether a request principal is authenticated.
+ *
+ * @param principal the request principal to check.
+ * @returns true if the principal is authenticated and can expose an account ID and value.
+ */
+/**
+ * Asserts that a request principal is authenticated.
+ *
+ * @param principal the request principal to assert.
+ */
+export function assertAuthenticatedRequestPrincipal(
+  principal: RequestPrincipal
+): asserts principal is AuthenticatedRequestPrincipal {
+  if (principal.isAuthenticated()) {
+    return
+  }
+  throw new Error('invalid.principal')
+}
+
+/**
+ * Creates a request-principal implementation from public simulation input.
+ *
+ * @param input the principal input from a simulation request.
+ * @returns a request-principal implementation for the input.
+ */
+export function requestPrincipalFromInput(input: SimulationRequestPrincipal): RequestPrincipal {
+  if (!isSimulationRequestPrincipal(input)) {
+    throw new Error('invalid.principal')
+  }
+  if (isAnonymousRequestPrincipal(input)) {
+    return new AnonymousRequestPrincipalImpl()
+  }
+  return new AuthenticatedRequestPrincipalImpl(input)
+}
+
+/**
+ * A string-valued authenticated request principal.
+ */
+export class AuthenticatedRequestPrincipalImpl implements AuthenticatedRequestPrincipal {
+  /**
+   * Create an authenticated request principal.
+   *
+   * @param rawValue the raw principal string.
+   */
   constructor(private readonly rawValue: string) {}
 
-  accountId(): string | undefined {
-    return this.value().split(':').at(4)
+  kind(): 'Authenticated' {
+    return 'Authenticated'
+  }
+
+  isAnonymous(): this is AnonymousRequestPrincipal {
+    return false
+  }
+
+  isAuthenticated(): this is AuthenticatedRequestPrincipal {
+    return true
   }
 
   public value(): string {
     return this.rawValue
   }
 
+  accountId(): string | undefined {
+    const arnParts = this.value().split(':')
+    if (arnParts.length < 6 || arnParts[0] !== 'arn') {
+      return undefined
+    }
+    return arnParts[4] || undefined
+  }
+
   //TODO: A principal is a Service Linked Role if it is an ARN and has the path arn:aws:iam::111111111111:role/aws-service-role/...
+}
+
+/**
+ * An unsigned anonymous request principal.
+ */
+export class AnonymousRequestPrincipalImpl implements AnonymousRequestPrincipal {
+  kind(): 'Anonymous' {
+    return 'Anonymous'
+  }
+
+  isAnonymous(): this is AnonymousRequestPrincipal {
+    return true
+  }
+
+  isAuthenticated(): this is AuthenticatedRequestPrincipal {
+    return false
+  }
 }

--- a/src/services/DefaultServiceAuthorizer.ts
+++ b/src/services/DefaultServiceAuthorizer.ts
@@ -11,6 +11,7 @@ import {
   type RequestAnalysis,
   type ResourceAnalysis
 } from '../evaluate.js'
+import { assertAuthenticatedRequestPrincipal } from '../request/requestPrincipal.js'
 import { type RequestResource } from '../request/requestResource.js'
 import { type ServiceAuthorizationRequest, type ServiceAuthorizer } from './ServiceAuthorizer.js'
 
@@ -101,9 +102,12 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
     const permissionBoundaryResult = request.permissionBoundaryAnalysis?.result
     const endpointPolicyResult = request.endpointAnalysis?.result
 
-    const principalAccount = request.request.principal.accountId()
+    const requestPrincipal = request.request.principal
+    const principalAccount = requestPrincipal.isAuthenticated()
+      ? requestPrincipal.accountId()
+      : undefined
     const resourceAccount = request.request.resource?.accountId()
-    const sameAccount = principalAccount === resourceAccount
+    const sameAccount = principalAccount !== undefined && principalAccount === resourceAccount
 
     const baseResult: Pick<
       RequestAnalysis,
@@ -126,6 +130,11 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
       permissionBoundaryAnalysis: request.permissionBoundaryAnalysis,
       endpointAnalysis: request.endpointAnalysis
     }
+
+    if (requestPrincipal.isAnonymous()) {
+      return this.authorizeAnonymousRequest(request, baseResult)
+    }
+    assertAuthenticatedRequestPrincipal(requestPrincipal)
 
     const coreResult = this.initialEvaluationResult(request)
     const blockedByLog = new BlockedByLog(coreResult)
@@ -167,7 +176,7 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
          * The request is allowed: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
          */
         if (resourcePolicyResult === 'Allowed') {
-          const principal = request.request.principal.value()
+          const principal = requestPrincipal.value()
           if (
             isAssumedRoleArn(principal) ||
             isIamUserArn(principal) ||
@@ -231,6 +240,75 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
   }
 
   /**
+   * Authorize an anonymous request after all policy analysis has been completed.
+   *
+   * @param request the service authorization request containing all analyses.
+   * @param baseResult the common request-analysis fields to include in the result.
+   * @returns the anonymous request authorization result.
+   */
+  private authorizeAnonymousRequest(
+    request: ServiceAuthorizationRequest,
+    baseResult: Pick<
+      RequestAnalysis,
+      | 'sameAccount'
+      | 'scpAnalysis'
+      | 'rcpAnalysis'
+      | 'resourceAnalysis'
+      | 'sessionAnalysis'
+      | 'identityAnalysis'
+      | 'permissionBoundaryAnalysis'
+      | 'endpointAnalysis'
+      | 'blockedBy'
+    >
+  ): RequestAnalysis {
+    const endpointPolicyResult = request.endpointAnalysis?.result
+    const coreResult = this.anonymousInitialEvaluationResult(request)
+    const blockedByLog = new BlockedByLog(coreResult)
+
+    if (request.rcpAnalysis.ouAnalysis.length > 0) {
+      blockedByLog.add('rcp', request.rcpAnalysis.result)
+    }
+
+    if (
+      endpointPolicyResult === 'ExplicitlyDenied' ||
+      endpointPolicyResult === 'ImplicitlyDenied'
+    ) {
+      blockedByLog.add('vpce', endpointPolicyResult)
+    }
+
+    const blockedReasons = blockedByLog.getBlockedBy()
+    if (blockedReasons.length !== 0) {
+      baseResult.blockedBy = blockedReasons
+    }
+
+    return {
+      result: blockedByLog.getResult(),
+      ...baseResult,
+      sameAccount: false
+    }
+  }
+
+  /**
+   * Evaluates whether an anonymous request has the resource-side grant required to be allowed.
+   *
+   * @param request the service authorization request containing all analyses.
+   * @returns the core anonymous result before applicable resource-side guardrails are applied.
+   */
+  private anonymousInitialEvaluationResult(request: ServiceAuthorizationRequest): EvaluationResult {
+    const resourcePolicyResult = request.resourceAnalysis?.result
+    if (resourcePolicyResult === 'Allowed') {
+      return 'Allowed'
+    }
+    if (
+      resourcePolicyResult === 'ExplicitlyDenied' ||
+      resourcePolicyResult === 'DeniedForAccount'
+    ) {
+      return 'ExplicitlyDenied'
+    }
+    return 'ImplicitlyDenied'
+  }
+
+  /**
    * Determines if the service trusts the principal's Account's IAM policies
    *
    * @param sameAccount - If the principal and resource are in the same account
@@ -271,16 +349,24 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
     const identityStatementResult = request.identityAnalysis.result
     const resourcePolicyResult = request.resourceAnalysis?.result
 
-    const principalAccount = request.request.principal.accountId()
+    const requestPrincipal = request.request.principal
+    const principalAccount = requestPrincipal.isAuthenticated()
+      ? requestPrincipal.accountId()
+      : undefined
     const resourceAccount = request.request.resource?.accountId()
-    const sameAccount = principalAccount === resourceAccount
+    const sameAccount = principalAccount !== undefined && principalAccount === resourceAccount
+
+    if (requestPrincipal.isAnonymous()) {
+      return this.anonymousInitialEvaluationResult(request)
+    }
+    assertAuthenticatedRequestPrincipal(requestPrincipal)
 
     if (sessionResult && sessionResult !== 'Allowed') {
       return sessionResult
     }
 
     // Service Principals
-    if (isServicePrincipal(request.request.principal.value())) {
+    if (isServicePrincipal(requestPrincipal.value())) {
       // Service principals are allowed if the resource policy allows them
       if (resourcePolicyResult === 'Allowed') {
         return 'Allowed'

--- a/src/services/StsServiceAuthorizer.ts
+++ b/src/services/StsServiceAuthorizer.ts
@@ -8,7 +8,10 @@ import { type ServiceAuthorizationRequest } from './ServiceAuthorizer.js'
  */
 export class StsServiceAuthorizer extends DefaultServiceAuthorizer {
   public override authorize(request: ServiceAuthorizationRequest): RequestAnalysis {
-    if (request.request.action.value().toLowerCase() === 'sts:getcalleridentity') {
+    if (
+      request.request.action.value().toLowerCase() === 'sts:getcalleridentity' &&
+      request.request.principal.isAuthenticated()
+    ) {
       return {
         result: 'Allowed',
         sameAccount: true

--- a/src/simulation_engine/simulation.ts
+++ b/src/simulation_engine/simulation.ts
@@ -1,4 +1,50 @@
 /**
+ * Explicit marker for an unsigned anonymous request.
+ */
+export interface AnonymousRequestPrincipal {
+  type: 'Anonymous'
+}
+
+/**
+ * Principal value for a simulation request.
+ */
+export type SimulationRequestPrincipal = string | AnonymousRequestPrincipal
+
+/**
+ * Convenience value for anonymous simulations.
+ */
+export const anonymousPrincipal: AnonymousRequestPrincipal = { type: 'Anonymous' }
+
+/**
+ * Checks whether a value is the anonymous request-principal marker.
+ *
+ * This guard intentionally accepts only the exact public anonymous shape so unsupported object fields
+ * cannot be confused with future principal variants.
+ *
+ * @param value the value to check.
+ * @returns true if the value is an anonymous request principal.
+ */
+export function isAnonymousRequestPrincipal(value: unknown): value is AnonymousRequestPrincipal {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    !Array.isArray(value) &&
+    Object.keys(value).length === 1 &&
+    (value as { type?: unknown }).type === 'Anonymous'
+  )
+}
+
+/**
+ * Checks whether a value is a supported simulation request principal.
+ *
+ * @param value the value to check.
+ * @returns true if the value is a string principal or the anonymous marker.
+ */
+export function isSimulationRequestPrincipal(value: unknown): value is SimulationRequestPrincipal {
+  return typeof value === 'string' || isAnonymousRequestPrincipal(value)
+}
+
+/**
  * Represents the policies attached to an OU, or account
  */
 export interface SimulationOrgPolicies {
@@ -16,7 +62,7 @@ export interface SimulationIdentityPolicy {
 
 export interface Simulation {
   request: {
-    principal: string
+    principal: SimulationRequestPrincipal
     action: string
     resource: {
       resource: string

--- a/src/simulation_engine/simulationEngine.test.ts
+++ b/src/simulation_engine/simulationEngine.test.ts
@@ -21,6 +21,7 @@ import {
   type ValidationError
 } from '@cloud-copilot/iam-policy'
 import { describe, expect, it, vi } from 'vitest'
+import { anonymousPrincipal } from '../index.js'
 import type { Simulation } from './simulation.js'
 import { normalizeSimulationParameters, runSimulation } from './simulationEngine.js'
 import type {
@@ -1539,6 +1540,207 @@ describe('runSimulation', () => {
       throw new Error('Expected wildcard result')
     }
     expect(response.overallResult).toEqual('ImplicitlyDenied')
+  })
+
+  describe('anonymous requests', () => {
+    const anonymousPublicSimulation = (): Simulation => ({
+      identityPolicies: [],
+      serviceControlPolicies: [],
+      resourceControlPolicies: [],
+      resourcePolicy: {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Allow',
+            Principal: '*',
+            Action: 's3:GetObject',
+            Resource: 'arn:aws:s3:::examplebucket/*'
+          }
+        ]
+      },
+      request: {
+        action: 's3:GetObject',
+        resource: {
+          resource: 'arn:aws:s3:::examplebucket/1234',
+          accountId: '123456789012'
+        },
+        principal: { type: 'Anonymous' },
+        contextVariables: {}
+      }
+    })
+
+    it('allows an anonymous request with a public resource policy and no RCP', async () => {
+      //Given an anonymous request with a public resource policy
+      const simulation = anonymousPublicSimulation()
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is allowed
+      expect(response.resultType).toEqual('single')
+      if (response.resultType !== 'single') {
+        throw new Error('Expected single result')
+      }
+      expect(response.overallResult).toEqual('Allowed')
+      expect(response.result.analysis.sameAccount).toEqual(false)
+    })
+
+    it('allows an anonymous request using the exported anonymousPrincipal constant', async () => {
+      //Given an anonymous request using the exported convenience constant
+      const simulation = anonymousPublicSimulation()
+      simulation.request.principal = anonymousPrincipal
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is allowed
+      expect(response.resultType).toEqual('single')
+      if (response.resultType !== 'single') {
+        throw new Error('Expected single result')
+      }
+      expect(response.overallResult).toEqual('Allowed')
+    })
+
+    it('does not include resource policy in blockedBy for anonymous resource-policy explicit deny', async () => {
+      //Given an anonymous request with a resource-policy explicit deny
+      const simulation = anonymousPublicSimulation()
+      simulation.resourcePolicy = {
+        Version: '2012-10-17',
+        Statement: [
+          {
+            Effect: 'Deny',
+            Principal: '*',
+            Action: 's3:GetObject',
+            Resource: 'arn:aws:s3:::examplebucket/*'
+          }
+        ]
+      }
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the resource policy is the core decision, not a blockedBy guardrail
+      expect(response.resultType).toEqual('single')
+      if (response.resultType !== 'single') {
+        throw new Error('Expected single result')
+      }
+      expect(response.overallResult).toEqual('ExplicitlyDenied')
+      expect(response.result.analysis.blockedBy).toBeUndefined()
+    })
+
+    it('implicitly denies an anonymous request without a resource policy', async () => {
+      //Given an anonymous request without a resource policy
+      const simulation = anonymousPublicSimulation()
+      simulation.resourcePolicy = undefined
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is implicitly denied
+      expect(response.resultType).toEqual('single')
+      if (response.resultType !== 'single') {
+        throw new Error('Expected single result')
+      }
+      expect(response.overallResult).toEqual('ImplicitlyDenied')
+    })
+
+    it('rejects anonymous requests with a session policy', async () => {
+      //Given an anonymous request with a session policy
+      const simulation = anonymousPublicSimulation()
+      simulation.sessionPolicy = { Statement: [{ Effect: 'Allow', Action: '*', Resource: '*' }] }
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is rejected before authorization
+      const errorResponse = assertErrorResult(response)
+      expect(errorResponse.errors.message).toEqual('anonymous.sessionPolicy.invalid')
+      expect(errorResponse.errors.anonymousRequestErrors).toEqual([
+        'anonymous.sessionPolicy.invalid'
+      ])
+    })
+
+    it('rejects anonymous requests with identity policies', async () => {
+      //Given an anonymous request with an identity policy
+      const simulation = anonymousPublicSimulation()
+      simulation.identityPolicies = [
+        {
+          name: 'IdentityPolicy',
+          policy: { Statement: [{ Effect: 'Allow', Action: '*', Resource: '*' }] }
+        }
+      ]
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is rejected before authorization
+      const errorResponse = assertErrorResult(response)
+      expect(errorResponse.errors.message).toEqual('anonymous.identityPolicies.invalid')
+    })
+
+    it('rejects anonymous requests with permission boundaries', async () => {
+      //Given an anonymous request with a permission boundary
+      const simulation = anonymousPublicSimulation()
+      simulation.permissionBoundaryPolicies = [
+        {
+          name: 'Boundary',
+          policy: { Statement: [{ Effect: 'Allow', Action: '*', Resource: '*' }] }
+        }
+      ]
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is rejected before authorization
+      const errorResponse = assertErrorResult(response)
+      expect(errorResponse.errors.message).toEqual('anonymous.permissionBoundaryPolicies.invalid')
+    })
+
+    it('rejects anonymous requests with service control policies', async () => {
+      //Given an anonymous request with an SCP
+      const simulation = anonymousPublicSimulation()
+      simulation.serviceControlPolicies = [
+        {
+          orgIdentifier: 'o-123',
+          policies: [
+            { name: 'Scp', policy: { Statement: [{ Effect: 'Deny', Action: '*', Resource: '*' }] } }
+          ]
+        }
+      ]
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is rejected before authorization
+      const errorResponse = assertErrorResult(response)
+      expect(errorResponse.errors.message).toEqual('anonymous.serviceControlPolicies.invalid')
+    })
+
+    it('rejects malformed object principals', async () => {
+      //Given a malformed object principal
+      const simulation = anonymousPublicSimulation()
+      simulation.request.principal = { type: 'User' } as any
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is rejected before authorization
+      const errorResponse = assertErrorResult(response)
+      expect(errorResponse.errors.message).toEqual('invalid.principal')
+    })
+
+    it('rejects anonymous principals with extra fields', async () => {
+      //Given an anonymous object principal with unsupported fields
+      const simulation = anonymousPublicSimulation()
+      simulation.request.principal = { type: 'Anonymous', accountId: '123456789012' } as any
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is rejected before authorization
+      const errorResponse = assertErrorResult(response)
+      expect(errorResponse.errors.message).toEqual('invalid.principal')
+    })
   })
 
   it('should return not allowed without erroring when an identity policy has a CloudFormation Sub resource string', async () => {

--- a/src/simulation_engine/simulationEngine.ts
+++ b/src/simulation_engine/simulationEngine.ts
@@ -29,7 +29,11 @@ import { calculateOverallResult } from './overallResult.js'
 import { getMatchingResourceStringsForPolicies } from './policyResources.js'
 import { expandShortArn } from '../util/resourceStrings.js'
 import { getResourceTypesForAction } from './resourceTypes.js'
-import { type Simulation } from './simulation.js'
+import {
+  isAnonymousRequestPrincipal,
+  isSimulationRequestPrincipal,
+  type Simulation
+} from './simulation.js'
 import { type SimulationOptions } from './simulationOptions.js'
 
 const DEFAULT_RCP = {
@@ -55,6 +59,7 @@ export interface SimulationErrors {
   permissionBoundaryErrors?: Record<string, ValidationError[]>
   resourcePolicyErrors?: ValidationError[]
   vpcEndpointErrors?: Record<string, ValidationError[]>
+  anonymousRequestErrors?: string[]
   message: string
 }
 
@@ -194,6 +199,29 @@ function validateOrReuse(
 }
 
 /**
+ * Finds principal-side policy inputs that are invalid for anonymous requests.
+ *
+ * @param simulation the simulation input to validate.
+ * @returns anonymous request validation error message identifiers.
+ */
+function anonymousRequestValidationErrors(simulation: Simulation): string[] {
+  const errors: string[] = []
+  if (simulation.sessionPolicy) {
+    errors.push('anonymous.sessionPolicy.invalid')
+  }
+  if (simulation.identityPolicies.length > 0) {
+    errors.push('anonymous.identityPolicies.invalid')
+  }
+  if ((simulation.permissionBoundaryPolicies?.length ?? 0) > 0) {
+    errors.push('anonymous.permissionBoundaryPolicies.invalid')
+  }
+  if (simulation.serviceControlPolicies.length > 0) {
+    errors.push('anonymous.serviceControlPolicies.invalid')
+  }
+  return errors
+}
+
+/**
  * Run a simulation with validation
  *
  * @param simulation The simulation to run
@@ -208,11 +236,35 @@ export async function runSimulation(
   const resourceArn = simulation.request.resource.resource
   const resourceHasWildcard = resourceArn.includes('*')
 
+  if (!isSimulationRequestPrincipal(principal)) {
+    return {
+      resultType: 'error',
+      errors: {
+        message: 'invalid.principal'
+      }
+    }
+  }
+
+  if (isAnonymousRequestPrincipal(principal)) {
+    const anonymousRequestErrors = anonymousRequestValidationErrors(simulation)
+    if (anonymousRequestErrors.length > 0) {
+      return {
+        resultType: 'error',
+        errors: {
+          anonymousRequestErrors,
+          message:
+            anonymousRequestErrors.length === 1
+              ? anonymousRequestErrors[0]
+              : 'anonymous.policies.invalid'
+        }
+      }
+    }
+  }
+
   if (simulation.sessionPolicy) {
     if (
-      !isIamRoleArn(principal) &&
-      !isAssumedRoleArn(principal) &&
-      !isFederatedUserArn(principal)
+      typeof principal !== 'string' ||
+      (!isIamRoleArn(principal) && !isAssumedRoleArn(principal) && !isFederatedUserArn(principal))
     ) {
       return {
         resultType: 'error',


### PR DESCRIPTION
## Summary
- add first-class anonymous request principal support via `anonymousPrincipal` and typed request principal variants
- authorize anonymous requests from resource policies while keeping SCP/identity/session/permission boundaries non-applicable
- validate exported anonymous simulations reject principal-side policies and malformed principal objects
- add anonymous authorization, principal matching, and validation tests

## Tests
- `npm test`
- `npm run build`

Note: `npm run format-check` now passes for the staged formatting fixes in this PR; prior failures were in formatting-only files included here.