### PR TITLE
feat: add S3 Block Public Access support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,23 @@ const simulation: Simulation = {
 const response = await runSimulation(simulation, {})
 ```
 
+### S3 Block Public Access
+
+For S3 requests, callers can provide the effective `RestrictPublicBuckets` setting with `additionalSettings.s3.blockPublicAccess`. iam-simulate does not fetch or determine this setting; provide `true` only when S3 Block Public Access should apply for the bucket/account being simulated.
+
+```typescript
+const simulation: Simulation = {
+  // request and policies...
+  additionalSettings: {
+    s3: {
+      blockPublicAccess: true
+    }
+  }
+}
+```
+
+When enabled, public S3 bucket policies can block anonymous and cross-account access with `blockedBy: ['s3-bpa']`.
+
 ## Installation
 
 ```bash

--- a/src/core_engine/CoreSimulatorEngine.ts
+++ b/src/core_engine/CoreSimulatorEngine.ts
@@ -24,7 +24,8 @@ import { requestMatchesStatementResources } from '../resource/resource.js'
 import { DefaultServiceAuthorizer } from '../services/DefaultServiceAuthorizer.js'
 import { IamServiceAuthorizer } from '../services/IamServiceAuthorizer.js'
 import { KmsServiceAuthorizer } from '../services/KmsServiceAuthorizer.js'
-import { type ServiceAuthorizer } from '../services/ServiceAuthorizer.js'
+import { type ServiceAuthorizer, type ServiceSettings } from '../services/ServiceAuthorizer.js'
+import { S3ServiceAuthorizer } from '../services/s3/S3ServiceAuthorizer.js'
 import { StsServiceAuthorizer } from '../services/StsServiceAuthorizer.js'
 import {
   identityStatementAllows,
@@ -126,12 +127,18 @@ export interface AuthorizationRequest {
    * The simulation parameters for the request.
    */
   simulationParameters: SimulationParameters
+
+  /**
+   * Caller-supplied service-specific settings that affect authorization.
+   */
+  serviceSettings?: ServiceSettings
 }
 
 const serviceEngines: Record<string, new () => ServiceAuthorizer> = {
   kms: KmsServiceAuthorizer,
   sts: StsServiceAuthorizer,
-  iam: IamServiceAuthorizer
+  iam: IamServiceAuthorizer,
+  s3: S3ServiceAuthorizer
 }
 
 /**
@@ -204,9 +211,11 @@ export function authorize(request: AuthorizationRequest): RequestAnalysis {
     scpAnalysis,
     rcpAnalysis,
     resourceAnalysis,
+    resourcePolicy: request.resourcePolicy,
     permissionBoundaryAnalysis,
     endpointAnalysis,
-    simulationParameters
+    simulationParameters,
+    serviceSettings: request.serviceSettings
   })
 
   if (simulationParameters.simulationMode === 'Discovery') {

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -9,7 +9,7 @@ export type ResourceEvaluationResult =
   | 'DeniedForAccount'
   | 'ImplicitlyDenied'
 
-export type BlockedReason = 'scp' | 'rcp' | 'vpce' | 'identity' | 'resource' | 'pb'
+export type BlockedReason = 'scp' | 'rcp' | 'vpce' | 'identity' | 'resource' | 'pb' | 's3-bpa'
 
 export interface IdentityAnalysis {
   result: EvaluationResult

--- a/src/services/ServiceAuthorizer.ts
+++ b/src/services/ServiceAuthorizer.ts
@@ -1,4 +1,7 @@
-import { type SimulationParameters } from '../core_engine/CoreSimulatorEngine.js'
+import {
+  type PolicyWithName,
+  type SimulationParameters
+} from '../core_engine/CoreSimulatorEngine.js'
 import {
   type IdentityAnalysis,
   type RcpAnalysis,
@@ -7,6 +10,14 @@ import {
   type ScpAnalysis
 } from '../evaluate.js'
 import { type AwsRequest } from '../request/request.js'
+import { type S3ServiceSettings } from './s3/s3BlockPublicAccess.js'
+
+export interface ServiceSettings {
+  /**
+   * S3-specific service settings.
+   */
+  s3?: S3ServiceSettings
+}
 
 export interface ServiceAuthorizationRequest {
   request: AwsRequest
@@ -14,10 +25,12 @@ export interface ServiceAuthorizationRequest {
   identityAnalysis: IdentityAnalysis
   scpAnalysis: ScpAnalysis
   resourceAnalysis: ResourceAnalysis
+  resourcePolicy: PolicyWithName | undefined
   rcpAnalysis: RcpAnalysis
   permissionBoundaryAnalysis: IdentityAnalysis | undefined
   endpointAnalysis: IdentityAnalysis | undefined
   simulationParameters: SimulationParameters
+  serviceSettings?: ServiceSettings
 }
 
 export interface ServiceAuthorizer {

--- a/src/services/s3/S3ServiceAuthorizer.test.ts
+++ b/src/services/s3/S3ServiceAuthorizer.test.ts
@@ -1,0 +1,411 @@
+import { loadPolicy } from '@cloud-copilot/iam-policy'
+import { describe, expect, it } from 'vitest'
+import { DiscoveryContextKeyConstraints } from '../../context_keys/discoveryContextKeyConstraints.js'
+import { authorize, type AuthorizationRequest } from '../../core_engine/CoreSimulatorEngine.js'
+import {
+  anonymousPrincipal,
+  type SimulationRequestPrincipal
+} from '../../simulation_engine/simulation.js'
+import { AwsRequestImpl } from '../../request/request.js'
+import { RequestContextImpl } from '../../requestContext.js'
+import { isStandardS3BucketResource } from './S3ServiceAuthorizer.js'
+
+interface S3BpaRuntimeTestCase {
+  name: string
+  principal: SimulationRequestPrincipal
+  action?: string
+  resource?: string
+  resourcePolicy?: object
+  identityPolicies?: object[]
+  context?: Record<string, string | string[]>
+  blockPublicAccess?: boolean
+  expected: {
+    result: 'Allowed' | 'ExplicitlyDenied' | 'ImplicitlyDenied'
+    blockedBy?: string[]
+  }
+}
+
+const s3BpaRuntimeCases: S3BpaRuntimeTestCase[] = [
+  {
+    name: 'does not block external access when BPA is missing',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: publicBucketPolicy(),
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'does not block anonymous access when BPA is explicitly disabled',
+    principal: anonymousPrincipal,
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: false,
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'blocks anonymous access through a public bucket policy when BPA is enabled',
+    principal: anonymousPrincipal,
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'blocks external signed access through a public bucket policy when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'blocks external signed access to a bucket ARN when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    action: 's3:GetBucketLocation',
+    resource: 'arn:aws:s3:::example-bucket',
+    identityPolicies: [allowIdentityPolicy('s3:GetBucketLocation', 'arn:aws:s3:::example-bucket')],
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetBucketLocation',
+          Resource: 'arn:aws:s3:::example-bucket'
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'blocks external signed access to an object wildcard ARN when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    resource: 'arn:aws:s3:::example-bucket/*',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'blocks external signed access to a wildcard bucket object ARN when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    resource: 'arn:aws:s3:::*/*',
+    identityPolicies: [allowIdentityPolicy('s3:GetObject', 'arn:aws:s3:::*/*')],
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'blocks external signed access to all resources wildcard when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    resource: '*',
+    identityPolicies: [allowIdentityPolicy('s3:GetObject', '*')],
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'allows same-account access through a public bucket policy when BPA is enabled',
+    principal: 'arn:aws:iam::111111111111:role/SameAccountRole',
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'does not override same-account explicit resource-policy deny when BPA is enabled',
+    principal: 'arn:aws:iam::111111111111:role/SameAccountRole',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*'
+        },
+        {
+          Effect: 'Deny',
+          Principal: { AWS: 'arn:aws:iam::111111111111:role/SameAccountRole' },
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*'
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['resource'] }
+  },
+  {
+    name: 'allows service principal access through a public bucket policy when BPA is enabled',
+    principal: 'cloudfront.amazonaws.com',
+    resourcePolicy: publicBucketPolicy(),
+    blockPublicAccess: true,
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'allows external role access through a specific non-public bucket policy when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::222222222222:role/ExternalRole' },
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*'
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'allows external account root principal access when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::222222222222:root' },
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*'
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'blocks external access when unrelated public statement taints the bucket policy',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetBucketLocation',
+          Resource: 'arn:aws:s3:::example-bucket'
+        },
+        {
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::222222222222:role/ExternalRole' },
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*'
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  },
+  {
+    name: 'allows matching org-constrained wildcard access when BPA is enabled',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    context: { 'aws:PrincipalOrgID': 'o-8jc0e05m21' },
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*',
+          Condition: { StringEquals: { 'aws:PrincipalOrgID': 'o-8jc0e05m21' } }
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'Allowed' }
+  },
+  {
+    name: 'blocks external access when SecureTransport condition does not make policy non-public',
+    principal: 'arn:aws:iam::222222222222:role/ExternalRole',
+    identityPolicies: [allowIdentityPolicy()],
+    context: { 'aws:SecureTransport': 'true' },
+    resourcePolicy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: 'arn:aws:s3:::example-bucket/*',
+          Condition: { Bool: { 'aws:SecureTransport': 'true' } }
+        }
+      ]
+    },
+    blockPublicAccess: true,
+    expected: { result: 'ExplicitlyDenied', blockedBy: ['s3-bpa'] }
+  }
+]
+
+describe('isStandardS3BucketResource', () => {
+  const resourceCases: Array<{ name: string; resource: string; expected: boolean }> = [
+    {
+      name: 'standard bucket ARN',
+      resource: 'arn:aws:s3:::example-bucket',
+      expected: true
+    },
+    {
+      name: 'standard object ARN',
+      resource: 'arn:aws:s3:::example-bucket/object.txt',
+      expected: true
+    },
+    {
+      name: 'standard object wildcard ARN',
+      resource: 'arn:aws:s3:::example-bucket/*',
+      expected: true
+    },
+    {
+      name: 'wildcard bucket ARN',
+      resource: 'arn:aws:s3:::*',
+      expected: true
+    },
+    {
+      name: 'wildcard bucket object ARN',
+      resource: 'arn:aws:s3:::*/*',
+      expected: true
+    },
+    {
+      name: 'all resources wildcard',
+      resource: '*',
+      expected: true
+    },
+    {
+      name: 'S3 access point ARN',
+      resource: 'arn:aws:s3:us-east-1:111111111111:accesspoint/example/object/test.txt',
+      expected: false
+    },
+    {
+      name: 'S3 Express bucket ARN',
+      resource: 'arn:aws:s3express:us-east-1:111111111111:bucket/example-bucket',
+      expected: false
+    },
+    {
+      name: 'S3 Outposts bucket ARN',
+      resource:
+        'arn:aws:s3-outposts:us-east-1:111111111111:outpost/op-1234567890abcdef0/bucket/example-bucket',
+      expected: false
+    },
+    {
+      name: 'S3 object lambda access point ARN',
+      resource: 'arn:aws:s3-object-lambda:us-east-1:111111111111:accesspoint/example',
+      expected: false
+    },
+    {
+      name: 'S3 ARN with region is not a standard bucket ARN',
+      resource: 'arn:aws:s3:us-east-1::example-bucket',
+      expected: false
+    },
+    {
+      name: 'S3 ARN with account is not a standard bucket ARN',
+      resource: 'arn:aws:s3::111111111111:example-bucket',
+      expected: false
+    },
+    {
+      name: 'empty S3 resource part is not a standard bucket ARN',
+      resource: 'arn:aws:s3:::',
+      expected: false
+    },
+    {
+      name: 'empty bucket name before object delimiter is not a standard bucket ARN',
+      resource: 'arn:aws:s3:::/object.txt',
+      expected: false
+    },
+    {
+      name: 'non-S3 ARN is not a standard bucket ARN',
+      resource: 'arn:aws:sqs:us-east-1:111111111111:example-queue',
+      expected: false
+    },
+    {
+      name: 'malformed resource is not a standard bucket ARN',
+      resource: 'example-bucket/object.txt',
+      expected: false
+    }
+  ]
+
+  it.each(resourceCases)('$name', ({ resource, expected }) => {
+    expect(isStandardS3BucketResource(resource)).toBe(expected)
+  })
+})
+
+describe('S3ServiceAuthorizer', () => {
+  it.each(s3BpaRuntimeCases)('$name', (testCase) => {
+    //Given an S3 authorization request
+    const request = authorizationRequest(testCase)
+
+    //When the request is authorized
+    const analysis = authorize(request)
+
+    //Then the S3 BPA runtime result should match expectations
+    expect(analysis.result).toBe(testCase.expected.result)
+    expect(analysis.blockedBy?.sort()).toEqual(testCase.expected.blockedBy?.sort())
+  })
+})
+
+function authorizationRequest(testCase: S3BpaRuntimeTestCase): AuthorizationRequest {
+  return {
+    request: new AwsRequestImpl(
+      testCase.principal,
+      {
+        resource: testCase.resource ?? 'arn:aws:s3:::example-bucket/object.txt',
+        accountId: '111111111111'
+      },
+      testCase.action ?? 's3:GetObject',
+      new RequestContextImpl(testCase.context ?? {})
+    ),
+    sessionPolicy: undefined,
+    identityPolicies: (testCase.identityPolicies ?? []).map((policy, index) =>
+      loadPolicy(policy, { name: `identity-${index}` })
+    ),
+    serviceControlPolicies: [],
+    resourceControlPolicies: [],
+    resourcePolicy: testCase.resourcePolicy
+      ? loadPolicy(testCase.resourcePolicy, { name: 'ResourcePolicy' })
+      : undefined,
+    permissionBoundaries: undefined,
+    vpcEndpointPolicies: undefined,
+    simulationParameters: {
+      simulationMode: 'Strict',
+      discoveryContextKeyConstraints: new DiscoveryContextKeyConstraints([])
+    },
+    serviceSettings: {
+      s3: {
+        blockPublicAccess: testCase.blockPublicAccess
+      }
+    }
+  }
+}
+
+function publicBucketPolicy(): object {
+  return {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Principal: '*',
+        Action: 's3:GetObject',
+        Resource: 'arn:aws:s3:::example-bucket/*'
+      }
+    ]
+  }
+}
+
+function allowIdentityPolicy(
+  action = 's3:GetObject',
+  resource = 'arn:aws:s3:::example-bucket/*'
+): object {
+  return {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Effect: 'Allow',
+        Action: action,
+        Resource: resource
+      }
+    ]
+  }
+}

--- a/src/services/s3/S3ServiceAuthorizer.ts
+++ b/src/services/s3/S3ServiceAuthorizer.ts
@@ -1,0 +1,89 @@
+import { isServicePrincipal } from '@cloud-copilot/iam-utils'
+import { type RequestAnalysis } from '../../evaluate.js'
+import { DefaultServiceAuthorizer } from '../DefaultServiceAuthorizer.js'
+import { type ServiceAuthorizationRequest } from '../ServiceAuthorizer.js'
+import { classifyS3RuntimePublicBucketPolicy } from './s3BlockPublicAccess.js'
+
+/**
+ * Service authorizer for S3 requests that applies S3 Block Public Access runtime behavior.
+ */
+export class S3ServiceAuthorizer extends DefaultServiceAuthorizer {
+  /**
+   * Authorizes an S3 request and applies RestrictPublicBuckets when the caller supplied
+   * S3 Block Public Access as enabled for the target bucket/account.
+   *
+   * @param request the service authorization request containing policy analyses and S3 settings
+   * @returns the final request analysis including an S3 BPA block when applicable
+   */
+  public override authorize(request: ServiceAuthorizationRequest): RequestAnalysis {
+    const baseResult = super.authorize(request)
+
+    if (baseResult.result !== 'Allowed') {
+      return baseResult
+    }
+
+    if (!isStandardS3BucketResource(request.request.resource.value())) {
+      return baseResult
+    }
+
+    if (request.serviceSettings?.s3?.blockPublicAccess !== true) {
+      return baseResult
+    }
+
+    if (!request.resourcePolicy) {
+      return baseResult
+    }
+
+    const classification = classifyS3RuntimePublicBucketPolicy(request.resourcePolicy)
+    if (classification.result === 'nonPublic') {
+      return baseResult
+    }
+
+    if (baseResult.sameAccount) {
+      return baseResult
+    }
+
+    const principal = request.request.principal
+    if (principal.isAuthenticated() && isServicePrincipal(principal.value())) {
+      return baseResult
+    }
+
+    // The base result is Allowed here, so there are no prior blocking reasons to merge.
+    return {
+      ...baseResult,
+      result: 'ExplicitlyDenied',
+      blockedBy: ['s3-bpa']
+    }
+  }
+}
+
+/**
+ * Checks whether a resource string is a standard S3 bucket or object ARN.
+ *
+ * @param resource the resource string to check
+ * @returns true if the resource is a standard S3 bucket/object ARN
+ */
+export function isStandardS3BucketResource(resource: string): boolean {
+  if (resource === '*') {
+    return true
+  }
+
+  const parts = resource.split(':')
+  if (parts.length < 6) {
+    return false
+  }
+
+  const service = parts[2]
+  const region = parts[3]
+  const account = parts[4]
+  const resourcePart = parts.slice(5).join(':')
+  const bucketNamePattern = resourcePart.split('/')[0]
+
+  return (
+    service === 's3' &&
+    region === '' &&
+    account === '' &&
+    resourcePart.length > 0 &&
+    bucketNamePattern.length > 0
+  )
+}

--- a/src/services/s3/s3BlockPublicAccess.test.ts
+++ b/src/services/s3/s3BlockPublicAccess.test.ts
@@ -1,0 +1,525 @@
+import { loadPolicy } from '@cloud-copilot/iam-policy'
+import { describe, expect, it } from 'vitest'
+import { classifyS3RuntimePublicBucketPolicy } from './s3BlockPublicAccess.js'
+
+interface RuntimePublicClassifierTestCase {
+  name: string
+  policy: object
+  expected: 'public' | 'nonPublic'
+  publicStatements?: Array<{ index: number; sid?: string }>
+}
+
+const bucketArn = 'arn:aws:s3:::example-bucket'
+const objectArn = `${bucketArn}/*`
+
+const classifierCases: RuntimePublicClassifierTestCase[] = [
+  {
+    name: 'bare wildcard principal is public',
+    policy: allowPolicy({ Sid: 'PublicWildcard', Principal: '*' }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PublicWildcard' }]
+  },
+  {
+    name: 'AWS wildcard principal is public',
+    policy: allowPolicy({ Sid: 'AwsWildcard', Principal: { AWS: '*' } }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'AwsWildcard' }]
+  },
+  {
+    name: 'public statement without Sid returns only the statement index',
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: objectArn
+        }
+      ]
+    },
+    expected: 'public',
+    publicStatements: [{ index: 1 }]
+  },
+  {
+    name: 'specific external role principal is non-public',
+    policy: allowPolicy({
+      Sid: 'SpecificRole',
+      Principal: { AWS: 'arn:aws:iam::222222222222:role/ExampleRole' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'external account root principal is non-public',
+    policy: allowPolicy({
+      Sid: 'ExternalRoot',
+      Principal: { AWS: 'arn:aws:iam::222222222222:root' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'service principal is non-public',
+    policy: allowPolicy({
+      Sid: 'CloudFrontService',
+      Principal: { Service: 'cloudfront.amazonaws.com' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalArn exact role condition is non-public',
+    policy: wildcardAllowWithCondition('PrincipalArnExact', {
+      ArnEquals: { 'aws:PrincipalArn': 'arn:aws:iam::111111111111:role/ExampleRole' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalArn wildcard role path in fixed account is non-public',
+    policy: wildcardAllowWithCondition('PrincipalArnRoleWildcard', {
+      ArnLike: { 'aws:PrincipalArn': 'arn:aws:iam::111111111111:role/*' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalArn wildcard account is public',
+    policy: wildcardAllowWithCondition('PrincipalArnWildcardAccount', {
+      ArnLike: { 'aws:PrincipalArn': 'arn:aws:iam::*:role/ExampleRole' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalArnWildcardAccount' }]
+  },
+  {
+    name: 'PrincipalAccount exact condition is non-public',
+    policy: wildcardAllowWithCondition('PrincipalAccountExact', {
+      StringEquals: { 'aws:PrincipalAccount': '111111111111' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalAccount wildcard condition is public',
+    policy: wildcardAllowWithCondition('PrincipalAccountWildcard', {
+      StringLike: { 'aws:PrincipalAccount': '1111*' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalAccountWildcard' }]
+  },
+  {
+    name: 'PrincipalOrgID exact condition is non-public',
+    policy: wildcardAllowWithCondition('PrincipalOrgExact', {
+      StringEquals: { 'aws:PrincipalOrgID': 'o-8jc0e05m21' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalOrgID wildcard condition is public',
+    policy: wildcardAllowWithCondition('PrincipalOrgWildcard', {
+      StringLike: { 'aws:PrincipalOrgID': 'o-*' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalOrgWildcard' }]
+  },
+  {
+    name: 'PrincipalOrgID StringNotEquals condition is public',
+    policy: wildcardAllowWithCondition('PrincipalOrgNotEquals', {
+      StringNotEquals: { 'aws:PrincipalOrgID': 'o-8jc0e05m21' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalOrgNotEquals' }]
+  },
+  {
+    name: 'PrincipalOrgPaths exact condition is non-public',
+    policy: wildcardAllowWithCondition('PrincipalOrgPathsExact', {
+      StringEquals: { 'aws:PrincipalOrgPaths': 'o-8jc0e05m21/r-root/ou-example/' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalOrgPaths wildcard suffix condition is non-public',
+    policy: wildcardAllowWithCondition('PrincipalOrgPathsWildcardSuffix', {
+      StringLike: { 'aws:PrincipalOrgPaths': 'o-8jc0e05m21/r-root/ou-example/*' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalTag exact condition is public',
+    policy: wildcardAllowWithCondition('PrincipalTagExact', {
+      StringEquals: { 'aws:PrincipalTag/Department': 'Engineering' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalTagExact' }]
+  },
+  {
+    name: 'PrincipalIsAWSService true condition is non-public',
+    policy: wildcardAllowWithCondition('PrincipalIsServiceTrue', {
+      Bool: { 'aws:PrincipalIsAWSService': 'true' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalIsAWSService true with StringEquals is non-public',
+    policy: wildcardAllowWithCondition('PrincipalIsServiceStringEqualsTrue', {
+      StringEquals: { 'aws:PrincipalIsAWSService': 'true' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalIsAWSService true with StringEqualsIgnoreCase is non-public',
+    policy: wildcardAllowWithCondition('PrincipalIsServiceIgnoreCaseTrue', {
+      StringEqualsIgnoreCase: { 'aws:PrincipalIsAWSService': 'TRUE' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalIsAWSService true with StringLike is non-public',
+    policy: wildcardAllowWithCondition('PrincipalIsServiceStringLikeTrue', {
+      StringLike: { 'aws:PrincipalIsAWSService': 'true' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalIsAWSService false condition is public',
+    policy: wildcardAllowWithCondition('PrincipalIsServiceFalse', {
+      Bool: { 'aws:PrincipalIsAWSService': 'false' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalIsServiceFalse' }]
+  },
+  {
+    name: 'PrincipalServiceName wildcard service pattern is non-public',
+    policy: wildcardAllowWithCondition('PrincipalServiceNameWildcard', {
+      StringLike: { 'aws:PrincipalServiceName': '*.amazonaws.com' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalServiceNamesList exact service name is non-public',
+    policy: wildcardAllowWithCondition('PrincipalServiceNamesListExact', {
+      'ForAnyValue:StringEquals': { 'aws:PrincipalServiceNamesList': 'cloudfront.amazonaws.com' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'PrincipalType condition is public',
+    policy: wildcardAllowWithCondition('PrincipalType', {
+      StringEquals: { 'aws:PrincipalType': 'AssumedRole' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'PrincipalType' }]
+  },
+  {
+    name: 'userid fixed prefix wildcard session suffix is non-public',
+    policy: wildcardAllowWithCondition('UserIdWildcardSession', {
+      StringLike: { 'aws:userid': 'AROAEXAMPLE:*' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'username exact condition is public',
+    policy: wildcardAllowWithCondition('UsernameExact', {
+      StringEquals: { 'aws:username': 'alice' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'UsernameExact' }]
+  },
+  {
+    name: 'SourceVpc exact condition is non-public',
+    policy: wildcardAllowWithCondition('SourceVpcExact', {
+      StringEquals: { 'aws:SourceVpc': 'vpc-0123456789abcdef0' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceVpc literal StringLike condition is non-public',
+    policy: wildcardAllowWithCondition('SourceVpcStringLikeLiteral', {
+      StringLike: { 'aws:SourceVpc': 'vpc-0123456789abcdef0' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceVpc StringEqualsIgnoreCase condition is non-public',
+    policy: wildcardAllowWithCondition('SourceVpcIgnoreCase', {
+      StringEqualsIgnoreCase: { 'aws:SourceVpc': 'vpc-0123456789abcdef0' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceVpc wildcard condition is public',
+    policy: wildcardAllowWithCondition('SourceVpcWildcard', {
+      StringLike: { 'aws:SourceVpc': 'vpc-*' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'SourceVpcWildcard' }]
+  },
+  {
+    name: 'SourceVpcArn exact condition is non-public',
+    policy: wildcardAllowWithCondition('SourceVpcArnExact', {
+      ArnEquals: {
+        'aws:SourceVpcArn': 'arn:aws:ec2:us-east-1:111111111111:vpc/vpc-0123456789abcdef0'
+      }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceVpcArn wildcard resource is public in the conservative runtime classifier',
+    policy: wildcardAllowWithCondition('SourceVpcArnWildcard', {
+      ArnLike: { 'aws:SourceVpcArn': 'arn:aws:ec2:us-east-1:111111111111:vpc/*' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'SourceVpcArnWildcard' }]
+  },
+  {
+    name: 'SourceVpce exact condition is non-public',
+    policy: wildcardAllowWithCondition('SourceVpceExact', {
+      StringEquals: { 'aws:SourceVpce': 'vpce-0123456789abcdef0' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'VpceAccount exact condition is non-public',
+    policy: wildcardAllowWithCondition('VpceAccountExact', {
+      StringEquals: { 'aws:VpceAccount': '111111111111' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'VpceOrgID exact condition is non-public',
+    policy: wildcardAllowWithCondition('VpceOrgExact', {
+      StringEquals: { 'aws:VpceOrgID': 'o-8jc0e05m21' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'VpceOrgPaths wildcard suffix condition is non-public',
+    policy: wildcardAllowWithCondition('VpceOrgPathsWildcardSuffix', {
+      StringLike: { 'aws:VpceOrgPaths': 'o-8jc0e05m21/r-root/ou-example/*' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'VpcSourceIp alone is public',
+    policy: wildcardAllowWithCondition('VpcSourceIp', {
+      IpAddress: { 'aws:VpcSourceIp': '10.0.0.0/8' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'VpcSourceIp' }]
+  },
+  {
+    name: 'SourceIp narrow public IPv4 range is non-public',
+    policy: wildcardAllowWithCondition('SourceIpNarrow', {
+      IpAddress: { 'aws:SourceIp': '203.0.113.10/32' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceIp RFC1918 private IPv4 range is non-public',
+    policy: wildcardAllowWithCondition('SourceIpPrivate', {
+      IpAddress: { 'aws:SourceIp': '10.0.0.0/8' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceIp broad public IPv4 range is public',
+    policy: wildcardAllowWithCondition('SourceIpBroad', {
+      IpAddress: { 'aws:SourceIp': '0.0.0.0/1' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'SourceIpBroad' }]
+  },
+  {
+    name: 'SourceIp IPv6 /32 range is non-public',
+    policy: wildcardAllowWithCondition('SourceIpIpv6Narrow', {
+      IpAddress: { 'aws:SourceIp': '2001:db8::/32' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceIp IPv6 range broader than /32 is public',
+    policy: wildcardAllowWithCondition('SourceIpIpv6Broad', {
+      IpAddress: { 'aws:SourceIp': '2001:db8::/31' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'SourceIpIpv6Broad' }]
+  },
+  {
+    name: 'SourceArn exact condition is non-public',
+    policy: wildcardAllowWithCondition('SourceArnExact', {
+      ArnEquals: {
+        'aws:SourceArn': 'arn:aws:cloudfront::111111111111:distribution/EXAMPLE'
+      }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SourceAccount exact condition is non-public',
+    policy: wildcardAllowWithCondition('SourceAccountExact', {
+      StringEquals: { 'aws:SourceAccount': '111111111111' }
+    }),
+    expected: 'nonPublic'
+  },
+  {
+    name: 'SecureTransport true condition is public',
+    policy: wildcardAllowWithCondition('SecureTransport', {
+      Bool: { 'aws:SecureTransport': 'true' }
+    }),
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'SecureTransport' }]
+  },
+  {
+    name: 'Deny-only wildcard policy is non-public',
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'DenyOnly',
+          Effect: 'Deny',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: objectArn
+        }
+      ]
+    },
+    expected: 'nonPublic'
+  },
+  {
+    name: 'specific allow plus wildcard deny is non-public',
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'SpecificAllow',
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::222222222222:role/ExampleRole' },
+          Action: 's3:GetObject',
+          Resource: objectArn
+        },
+        {
+          Sid: 'WildcardDeny',
+          Effect: 'Deny',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: objectArn
+        }
+      ]
+    },
+    expected: 'nonPublic'
+  },
+  {
+    name: 'wildcard allow narrowed by deny is runtime-public',
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'WildcardAllow',
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: objectArn
+        },
+        {
+          Sid: 'DenyOutsideOrg',
+          Effect: 'Deny',
+          Principal: '*',
+          Action: 's3:GetObject',
+          Resource: objectArn,
+          Condition: { StringNotEquals: { 'aws:PrincipalOrgID': 'o-8jc0e05m21' } }
+        }
+      ]
+    },
+    expected: 'public',
+    publicStatements: [{ index: 1, sid: 'WildcardAllow' }]
+  },
+  {
+    name: 'mixed public statement and specific role statement is public',
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Sid: 'SpecificRole',
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::222222222222:role/ExampleRole' },
+          Action: 's3:GetObject',
+          Resource: objectArn
+        },
+        {
+          Sid: 'PublicStatement',
+          Effect: 'Allow',
+          Principal: '*',
+          Action: 's3:GetBucketLocation',
+          Resource: bucketArn
+        }
+      ]
+    },
+    expected: 'public',
+    publicStatements: [{ index: 2, sid: 'PublicStatement' }]
+  },
+  {
+    name: 'mixed org-constrained wildcard and specific role is non-public',
+    policy: {
+      Version: '2012-10-17',
+      Statement: [
+        wildcardAllowStatement('OrgConstrained', {
+          StringEquals: { 'aws:PrincipalOrgID': 'o-8jc0e05m21' }
+        }),
+        {
+          Sid: 'SpecificRole',
+          Effect: 'Allow',
+          Principal: { AWS: 'arn:aws:iam::222222222222:role/ExampleRole' },
+          Action: 's3:GetObject',
+          Resource: objectArn
+        }
+      ]
+    },
+    expected: 'nonPublic'
+  }
+]
+
+describe('classifyS3RuntimePublicBucketPolicy', () => {
+  it.each(classifierCases)('$name', (testCase) => {
+    //Given a loaded S3 bucket policy
+    const policy = loadPolicy(testCase.policy, { name: 'ResourcePolicy' })
+
+    //When the policy is classified for runtime RestrictPublicBuckets behavior
+    const result = classifyS3RuntimePublicBucketPolicy(policy)
+
+    //Then the classification should match the expected result
+    expect(result.result).toBe(testCase.expected)
+    if (testCase.expected === 'public') {
+      expect(result).toEqual({
+        result: 'public',
+        publicStatements: testCase.publicStatements
+      })
+    }
+  })
+})
+
+function allowPolicy(options: { Sid: string; Principal: unknown }): object {
+  return {
+    Version: '2012-10-17',
+    Statement: [
+      {
+        Sid: options.Sid,
+        Effect: 'Allow',
+        Principal: options.Principal,
+        Action: 's3:GetObject',
+        Resource: objectArn
+      }
+    ]
+  }
+}
+
+function wildcardAllowWithCondition(sid: string, condition: object): object {
+  return {
+    Version: '2012-10-17',
+    Statement: [wildcardAllowStatement(sid, condition)]
+  }
+}
+
+function wildcardAllowStatement(sid: string, condition: object): object {
+  return {
+    Sid: sid,
+    Effect: 'Allow',
+    Principal: '*',
+    Action: 's3:GetObject',
+    Resource: objectArn,
+    Condition: condition
+  }
+}

--- a/src/services/s3/s3BlockPublicAccess.ts
+++ b/src/services/s3/s3BlockPublicAccess.ts
@@ -1,0 +1,423 @@
+import { type Policy, type Statement } from '@cloud-copilot/iam-policy'
+import { splitArnParts } from '../../util.js'
+
+/**
+ * Caller-supplied S3 Block Public Access settings for simulation.
+ */
+export interface S3ServiceSettings {
+  /**
+   * Whether S3 Block Public Access is enabled for the request target.
+   */
+  blockPublicAccess?: boolean
+}
+
+/**
+ * Classification of a standard S3 bucket policy for runtime RestrictPublicBuckets behavior.
+ */
+export type S3RuntimePublicPolicyClassification =
+  | {
+      /**
+       * The bucket policy is public for runtime RestrictPublicBuckets behavior.
+       */
+      result: 'public'
+
+      /**
+       * Allow statements that make the policy public.
+       */
+      publicStatements: S3RuntimePublicStatement[]
+    }
+  | {
+      /**
+       * The bucket policy is not public for runtime RestrictPublicBuckets behavior.
+       */
+      result: 'nonPublic'
+    }
+
+/**
+ * Identifies an Allow statement that makes a bucket policy public.
+ */
+export interface S3RuntimePublicStatement {
+  /**
+   * The 1-based statement index in the policy.
+   */
+  index: number
+
+  /**
+   * The statement Sid, if present.
+   */
+  sid?: string
+}
+
+/**
+ * Classifies a standard S3 bucket policy as public or non-public for runtime
+ * RestrictPublicBuckets behavior.
+ *
+ * @param policy the loaded S3 bucket policy to classify
+ * @returns whether the policy is runtime-public and, when public, the public statements
+ */
+export function classifyS3RuntimePublicBucketPolicy(
+  policy: Policy<unknown>
+): S3RuntimePublicPolicyClassification {
+  const publicStatements = policy
+    .statements()
+    .filter((statement) => statement.isAllow() && statementIsRuntimePublic(statement))
+    .map((statement) => statementIdentifier(statement))
+
+  if (publicStatements.length > 0) {
+    return { result: 'public', publicStatements }
+  }
+
+  return { result: 'nonPublic' }
+}
+
+/**
+ * Determines whether an individual Allow statement makes a bucket policy runtime-public.
+ *
+ * @param statement the statement to classify
+ * @returns true if the statement is public for runtime RestrictPublicBuckets behavior
+ */
+function statementIsRuntimePublic(statement: Statement): boolean {
+  if (!statement.isPrincipalStatement()) {
+    return true
+  }
+
+  const principals = statement.principals()
+  if (principals.some((principal) => principal.isWildcardPrincipal())) {
+    return !hasPublicAccessLimitingCondition(statement)
+  }
+
+  return false
+}
+
+/**
+ * Gets the statement index and Sid for classifier output.
+ *
+ * @param statement the statement to identify
+ * @returns the statement index and optional Sid
+ */
+function statementIdentifier(statement: Statement): S3RuntimePublicStatement {
+  return {
+    index: statement.index(),
+    ...(statement.sid() ? { sid: statement.sid() } : {})
+  }
+}
+
+/**
+ * Determines whether a wildcard-principal statement has a condition that limits access
+ * enough to be non-public for S3 BPA runtime classification.
+ *
+ * @param statement the wildcard-principal statement to inspect
+ * @returns true if a supported condition makes the statement non-public
+ */
+function hasPublicAccessLimitingCondition(statement: Statement): boolean {
+  const conditionMap = statement.conditionMap()
+  if (!conditionMap) {
+    return false
+  }
+
+  return (
+    hasFixedValueCondition(conditionMap, 'aws:PrincipalOrgID') ||
+    hasFixedValueCondition(conditionMap, 'aws:PrincipalAccount') ||
+    hasPrincipalArnLimitingCondition(conditionMap) ||
+    hasOrgPathLimitingCondition(conditionMap, 'aws:PrincipalOrgPaths') ||
+    hasAwsServicePrincipalLimitingCondition(conditionMap) ||
+    hasPrincipalServiceNameLimitingCondition(conditionMap) ||
+    hasUseridLimitingCondition(conditionMap) ||
+    hasFixedValueCondition(conditionMap, 'aws:SourceVpce') ||
+    hasFixedValueCondition(conditionMap, 'aws:SourceVpc') ||
+    hasSourceVpcArnLimitingCondition(conditionMap) ||
+    hasFixedValueCondition(conditionMap, 'aws:VpceAccount') ||
+    hasFixedValueCondition(conditionMap, 'aws:VpceOrgID') ||
+    hasOrgPathLimitingCondition(conditionMap, 'aws:VpceOrgPaths') ||
+    hasSourceIpLimitingCondition(conditionMap) ||
+    hasFixedArnCondition(conditionMap, 'aws:SourceArn') ||
+    hasFixedValueCondition(conditionMap, 'aws:SourceAccount')
+  )
+}
+
+/**
+ * Checks for exact fixed-value conditions for account, org, VPC, and similar keys.
+ *
+ * @param conditionMap the statement condition map
+ * @param key the condition key to inspect
+ * @returns true if the key is constrained to fixed values by supported operators
+ */
+function hasFixedValueCondition(
+  conditionMap: Record<string, Record<string, string[]>>,
+  key: string
+): boolean {
+  return conditionEntries(conditionMap, key).some(
+    ({ operator, values }) =>
+      ['StringEquals', 'StringEqualsIgnoreCase', 'ForAnyValue:StringEquals'].includes(operator) ||
+      (operator === 'StringLike' && values.every((value) => !hasWildcard(value)))
+  )
+}
+
+/**
+ * Checks for public-access-limiting aws:PrincipalArn conditions.
+ *
+ * @param conditionMap the statement condition map
+ * @returns true if PrincipalArn is constrained to a fixed account principal pattern
+ */
+function hasPrincipalArnLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>
+): boolean {
+  return conditionEntries(conditionMap, 'aws:PrincipalArn').some(({ operator, values }) => {
+    if (operator === 'ArnEquals') {
+      return values.every(isArnWithFixedAccount)
+    }
+    if (operator === 'ArnLike') {
+      return values.every(
+        (value) => isArnWithFixedAccount(value) && arnWildcardOnlyInResource(value)
+      )
+    }
+    return false
+  })
+}
+
+/**
+ * Checks for exact SourceVpcArn conditions.
+ *
+ * @param conditionMap the statement condition map
+ * @returns true if SourceVpcArn is constrained to exact ARNs
+ */
+function hasSourceVpcArnLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>
+): boolean {
+  return hasFixedArnCondition(conditionMap, 'aws:SourceVpcArn')
+}
+
+/**
+ * Checks for fixed ARN conditions.
+ *
+ * @param conditionMap the statement condition map
+ * @param key the condition key to inspect
+ * @returns true if the key is constrained to fixed ARN values
+ */
+function hasFixedArnCondition(
+  conditionMap: Record<string, Record<string, string[]>>,
+  key: string
+): boolean {
+  return conditionEntries(conditionMap, key).some(
+    ({ operator, values }) => operator === 'ArnEquals' && values.every(isArnWithFixedAccount)
+  )
+}
+
+/**
+ * Checks for AWS Organizations path conditions with fixed org path prefixes.
+ *
+ * @param conditionMap the statement condition map
+ * @param key the condition key to inspect
+ * @returns true if the path condition is fixed or uses a documented suffix wildcard shape
+ */
+function hasOrgPathLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>,
+  key: string
+): boolean {
+  return conditionEntries(conditionMap, key).some(({ operator, values }) => {
+    if (operator === 'StringEquals') {
+      return values.every(isFixedOrgPath)
+    }
+    if (operator === 'StringLike') {
+      return values.every(isFixedOrgPathWithOptionalSuffixWildcard)
+    }
+    return false
+  })
+}
+
+/**
+ * Checks for conditions that limit access to AWS service principals.
+ *
+ * @param conditionMap the statement condition map
+ * @returns true if the statement is limited to AWS service principals
+ */
+function hasAwsServicePrincipalLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>
+): boolean {
+  return conditionEntries(conditionMap, 'aws:PrincipalIsAWSService').some(
+    ({ operator, values }) =>
+      ['Bool', 'StringEquals', 'StringEqualsIgnoreCase', 'StringLike'].includes(operator) &&
+      values.every((value) => value.toLowerCase() === 'true')
+  )
+}
+
+/**
+ * Checks for service-principal name conditions.
+ *
+ * @param conditionMap the statement condition map
+ * @returns true if the statement is limited to service principal names
+ */
+function hasPrincipalServiceNameLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>
+): boolean {
+  return ['aws:PrincipalServiceName', 'aws:PrincipalServiceNamesList'].some((key) =>
+    conditionEntries(conditionMap, key).some(({ operator, values }) => {
+      return (
+        [
+          'StringEquals',
+          'ForAnyValue:StringEquals',
+          'StringLike',
+          'ForAnyValue:StringLike'
+        ].includes(operator) && values.every(isServiceNamePattern)
+      )
+    })
+  )
+}
+
+/**
+ * Checks for aws:userid conditions with a fixed stable ID prefix.
+ *
+ * @param conditionMap the statement condition map
+ * @returns true if userid is constrained to exact values or fixed-prefix session suffix wildcards
+ */
+function hasUseridLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>
+): boolean {
+  return conditionEntries(conditionMap, 'aws:userid').some(({ operator, values }) => {
+    if (operator === 'StringEquals') {
+      return values.every((value) => !hasWildcard(value))
+    }
+    if (operator === 'StringLike') {
+      return values.every((value) => /^[A-Z0-9]+:\*$/.test(value))
+    }
+    return false
+  })
+}
+
+/**
+ * Checks for sufficiently narrow aws:SourceIp conditions.
+ *
+ * @param conditionMap the statement condition map
+ * @returns true if SourceIp ranges are narrow enough to be non-public
+ */
+function hasSourceIpLimitingCondition(
+  conditionMap: Record<string, Record<string, string[]>>
+): boolean {
+  return conditionEntries(conditionMap, 'aws:SourceIp').some(
+    ({ operator, values }) => operator === 'IpAddress' && values.every(sourceIpRangeIsNonPublic)
+  )
+}
+
+/**
+ * Gets condition entries for a key using case-insensitive key matching.
+ *
+ * @param conditionMap the statement condition map
+ * @param key the condition key to inspect
+ * @returns matching condition entries
+ */
+function conditionEntries(
+  conditionMap: Record<string, Record<string, string[]>>,
+  key: string
+): Array<{ operator: string; values: string[] }> {
+  const entries: Array<{ operator: string; values: string[] }> = []
+  for (const [operator, keyValues] of Object.entries(conditionMap)) {
+    for (const [conditionKey, values] of Object.entries(keyValues)) {
+      if (conditionKey.toLowerCase() === key.toLowerCase()) {
+        entries.push({ operator, values })
+      }
+    }
+  }
+  return entries
+}
+
+/**
+ * Checks whether an ARN pattern has a fixed account component.
+ *
+ * @param value the ARN or ARN pattern to inspect
+ * @returns true if the account component is fixed and non-wildcard
+ */
+function isArnWithFixedAccount(value: string): boolean {
+  const arn = splitArnParts(value)
+  return !!arn.accountId && !hasWildcard(arn.accountId)
+}
+
+/**
+ * Checks whether ARN wildcards are limited to the resource component.
+ *
+ * @param value the ARN pattern to inspect
+ * @returns true if partition, service, region, and account are fixed
+ */
+function arnWildcardOnlyInResource(value: string): boolean {
+  const arn = splitArnParts(value)
+  return ![arn.partition, arn.service, arn.region, arn.accountId].some((part) =>
+    part ? hasWildcard(part) : false
+  )
+}
+
+/**
+ * Checks whether a string has IAM wildcard characters.
+ *
+ * @param value the value to inspect
+ * @returns true if the value contains `*` or `?`
+ */
+function hasWildcard(value: string): boolean {
+  return value.includes('*') || value.includes('?')
+}
+
+/**
+ * Checks whether an Organizations path has a fixed org/root path prefix.
+ *
+ * @param value the org path value to inspect
+ * @returns true if the value is fixed and starts with an org path
+ */
+function isFixedOrgPath(value: string): boolean {
+  return /^o-[a-z0-9]+\/[^*?]+/.test(value) && !hasWildcard(value)
+}
+
+/**
+ * Checks whether an Organizations path is fixed or uses a suffix wildcard.
+ *
+ * @param value the org path value to inspect
+ * @returns true if the value has a fixed org path prefix and optional trailing wildcard
+ */
+function isFixedOrgPathWithOptionalSuffixWildcard(value: string): boolean {
+  if (!value.endsWith('*')) {
+    return isFixedOrgPath(value)
+  }
+  const prefix = value.slice(0, -1)
+  return /^o-[a-z0-9]+\/[^*?]+/.test(prefix) && !hasWildcard(prefix)
+}
+
+/**
+ * Checks whether a value is an AWS service-name pattern.
+ *
+ * @param value the service name or pattern to inspect
+ * @returns true if the value is an amazonaws.com service name pattern
+ */
+function isServiceNamePattern(value: string): boolean {
+  return /^([a-z0-9-]+|\*)\.(amazonaws\.com|amazonaws\.com\.cn)$/.test(value)
+}
+
+/**
+ * Determines whether a SourceIp CIDR is narrow/private enough to be non-public.
+ *
+ * @param cidr the CIDR value to inspect
+ * @returns true if the CIDR is non-public for S3 BPA classification
+ */
+function sourceIpRangeIsNonPublic(cidr: string): boolean {
+  const [address, prefixString] = cidr.split('/')
+  const prefix = Number(prefixString)
+  if (!address || !Number.isInteger(prefix)) {
+    return false
+  }
+
+  if (address.includes(':')) {
+    return prefix >= 32
+  }
+
+  const firstOctet = Number(address.split('.')[0])
+  const secondOctet = Number(address.split('.')[1])
+  if (!Number.isInteger(firstOctet) || !Number.isInteger(secondOctet)) {
+    return false
+  }
+
+  if (
+    firstOctet === 10 ||
+    (firstOctet === 172 && secondOctet >= 16 && secondOctet <= 31) ||
+    (firstOctet === 192 && secondOctet === 168)
+  ) {
+    return true
+  }
+
+  return prefix >= 8
+}

--- a/src/simulation_engine/simulation.ts
+++ b/src/simulation_engine/simulation.ts
@@ -119,6 +119,12 @@ export interface Simulation {
        * If an S3 bucket request, whether ABAC is enabled on the bucket
        */
       bucketAbacEnabled?: boolean
+
+      /**
+       * Caller-supplied effective S3 Block Public Access setting for RestrictPublicBuckets.
+       * iam-simulate does not determine this value from AWS; callers must provide it.
+       */
+      blockPublicAccess?: boolean
     }
   }
 }

--- a/src/simulation_engine/simulationEngine.test.ts
+++ b/src/simulation_engine/simulationEngine.test.ts
@@ -1601,6 +1601,27 @@ describe('runSimulation', () => {
       expect(response.overallResult).toEqual('Allowed')
     })
 
+    it('blocks an anonymous S3 request when block public access is enabled', async () => {
+      //Given an anonymous request with a public bucket policy and S3 BPA enabled
+      const simulation = anonymousPublicSimulation()
+      simulation.additionalSettings = {
+        s3: {
+          blockPublicAccess: true
+        }
+      }
+
+      //When the simulation is run
+      const response = await runSimulation(simulation, {})
+
+      //Then the request is blocked by S3 BPA
+      expect(response.resultType).toEqual('single')
+      if (response.resultType !== 'single') {
+        throw new Error('Expected single result')
+      }
+      expect(response.overallResult).toEqual('ExplicitlyDenied')
+      expect(response.result.analysis.blockedBy).toEqual(['s3-bpa'])
+    })
+
     it('does not include resource policy in blockedBy for anonymous resource-policy explicit deny', async () => {
       //Given an anonymous request with a resource-policy explicit deny
       const simulation = anonymousPublicSimulation()

--- a/src/simulation_engine/simulationEngine.ts
+++ b/src/simulation_engine/simulationEngine.ts
@@ -501,6 +501,11 @@ export async function runSimulation(
       simulationParameters: {
         simulationMode: simulationMode,
         discoveryContextKeyConstraints
+      },
+      serviceSettings: {
+        s3: {
+          blockPublicAccess: simulation.additionalSettings?.s3?.blockPublicAccess
+        }
       }
     })
 

--- a/src/simulation_engine/unsafeSimulationEngine.ts
+++ b/src/simulation_engine/unsafeSimulationEngine.ts
@@ -72,6 +72,11 @@ export function runUnsafeSimulation(
     simulationParameters: {
       simulationMode: 'Strict',
       discoveryContextKeyConstraints: new DiscoveryContextKeyConstraints([])
+    },
+    serviceSettings: {
+      s3: {
+        blockPublicAccess: simulation.additionalSettings?.s3?.blockPublicAccess
+      }
     }
   })
 


### PR DESCRIPTION
## Summary
- add S3 runtime-public bucket policy classification for RestrictPublicBuckets behavior
- add caller-supplied `additionalSettings.s3.blockPublicAccess` and thread it through S3 authorization
- return `ExplicitlyDenied` with `blockedBy: ['s3-bpa']` for applicable anonymous/cross-account public bucket policy access
- document the S3 BPA setting and add dedicated S3 BPA authorizer/classifier tests

## Validation
- `npm run build`
- `npm run format-check`
- `npm test`