### PR TITLE
fix: resolve cross-prefix condition keys

### DIFF
--- a/src/context_keys/contextKeys.test.ts
+++ b/src/context_keys/contextKeys.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { isActualContextKey, typeForContextKey } from './contextKeys.js'
+import { isActualContextKey, normalizeContextKeyCase, typeForContextKey } from './contextKeys.js'
 
 describe('isActualContextKey', () => {
   it('should return true for a global context key', async () => {
@@ -112,6 +112,17 @@ describe('isActualContextKey', () => {
     expect(result).toBeTruthy()
   })
 
+  it('should return true for a valid cross-prefix Cognito Identity condition key', async () => {
+    //Given a Cognito Identity condition key whose prefix is not the owning service prefix
+    const key = 'cognito-identity-unauth:IdentityPoolArn'
+
+    //When the key is checked
+    const result = await isActualContextKey(key)
+
+    //Then the result should be true
+    expect(result).toBeTruthy()
+  })
+
   it('should return true for a OIDC key', async () => {
     //For a given set of OIDC keys
     //https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_iam-condition-keys.html#condition-keys-wif
@@ -145,6 +156,19 @@ describe('isActualContextKey', () => {
   })
 })
 
+describe('normalizeContextKeyCase', () => {
+  it('should normalize a valid cross-prefix Cognito Identity condition key', async () => {
+    //Given a Cognito Identity condition key whose prefix is not the owning service prefix
+    const key = 'cognito-identity-UNAUTH:identitypoolarn'
+
+    //When the key case is normalized
+    const result = await normalizeContextKeyCase(key)
+
+    //Then the key should resolve through the owning service condition keys
+    expect(result).toEqual('cognito-identity-unauth:IdentityPoolArn')
+  })
+})
+
 describe('typeForContextKey', () => {
   it('should return a service key with a slash in it', async () => {
     //Given a service key
@@ -155,5 +179,16 @@ describe('typeForContextKey', () => {
 
     //Then the result should be returned
     expect(result).toEqual('String')
+  })
+
+  it('should return the type for a valid cross-prefix Cognito Identity condition key', async () => {
+    //Given a Cognito Identity condition key whose prefix is not the owning service prefix
+    const key = 'cognito-identity-unauth:IdentityPoolArn'
+
+    //When the type is gotten
+    const result = await typeForContextKey(key)
+
+    //Then the key should resolve through the owning service condition keys
+    expect(result).toEqual('ARN')
   })
 })

--- a/src/context_keys/contextKeys.ts
+++ b/src/context_keys/contextKeys.ts
@@ -1,11 +1,4 @@
-import {
-  type ConditionKey,
-  findConditionKey,
-  iamConditionKeyDetails,
-  iamConditionKeyExists,
-  iamConditionKeysForService,
-  iamServiceExists
-} from '@cloud-copilot/iam-data'
+import { type ConditionKey, findConditionKey } from '@cloud-copilot/iam-data'
 import { getGlobalConditionKeyWithOrWithoutPrefix } from '../global_conditions/globalConditionKeys.js'
 import { type ConditionKeyType } from './contextKeyTypes.js'
 
@@ -55,41 +48,7 @@ export async function isActualContextKey(key: string): Promise<boolean> {
  * @returns The details for the context key if it exists. if the key has variables in it it will return the details for the variable key
  */
 async function serviceContextKeyDetails(contextKey: string): Promise<ConditionKey | undefined> {
-  const [service, key] = contextKeyParts(contextKey.toLowerCase())
-
-  const serviceExists = await iamServiceExists(service)
-  if (!serviceExists) {
-    return undefined
-  }
-
-  if (key.includes('/')) {
-    const prefix = service + ':' + key.slice(0, key.indexOf('/') + 1)
-    const allConditionsKeys = await iamConditionKeysForService(service)
-    const matchingKey = allConditionsKeys.find((k) => k.toLowerCase().startsWith(prefix))
-    if (matchingKey) {
-      return await iamConditionKeyDetails(service, matchingKey)
-    }
-    return undefined
-  }
-
-  const exists = await iamConditionKeyExists(service, contextKey)
-  if (!exists) {
-    return undefined
-  }
-  return iamConditionKeyDetails(service, contextKey)
-}
-
-/**
- * Split a context key into the service and the rest of the key. This has to be a special
- * method because context keys with variables may have a colon in the variable section,
- * because of course they can.
- *
- * @param contextKey The context key to split
- * @returns A tuple with the service and the rest of the key
- */
-export function contextKeyParts(contextKey: string): [string, string] {
-  const colonIndex = contextKey.indexOf(':')
-  return [contextKey.slice(0, colonIndex), contextKey.slice(colonIndex + 1)]
+  return findConditionKey(contextKey)
 }
 
 /**

--- a/src/simulation_engine/simulationEngine.test.ts
+++ b/src/simulation_engine/simulationEngine.test.ts
@@ -1,5 +1,6 @@
 import {
   type ConditionKey,
+  findConditionKey,
   getAllGlobalConditionKeys,
   getGlobalConditionKeyByName,
   getGlobalConditionKeyByPrefix,
@@ -115,6 +116,17 @@ vi.mocked(iamConditionKeyDetails).mockImplementation(async (service, key) => {
 
 vi.mocked(iamConditionKeyExists).mockImplementation(async (service, key) => {
   return mockKeyDetails[key.toLowerCase()] !== undefined
+})
+
+vi.mocked(findConditionKey).mockImplementation(async (key) => {
+  const normalizedKey = key.toLowerCase()
+  if (mockKeyDetails[normalizedKey]) {
+    return mockKeyDetails[normalizedKey]
+  }
+  if (normalizedKey.startsWith('s3:buckettag/')) {
+    return mockKeyDetails['s3:buckettag/${tagkey}']
+  }
+  return undefined
 })
 
 vi.mocked(iamActionExists).mockImplementation(async (service, action) => {


### PR DESCRIPTION
## Summary
- delegate service context key detail lookup to iam-data's canonical findConditionKey resolver
- add regression coverage for Cognito Identity auth/unauth cross-prefix condition keys
- update simulation engine test mocks for the new resolver path

## Root cause / fix
Valid keys such as `cognito-identity-unauth:IdentityPoolArn` are published under a prefix that is not itself an IAM service prefix. The previous resolver manually split the context key prefix and checked it with `iamServiceExists`, so it rejected these valid keys. `findConditionKey` already handles unassociated condition-key prefixes generated from iam-data, so iam-simulate now uses that resolver.

## Tests
- `npx vitest --run src/context_keys/contextKeys.test.ts`
- `npx vitest --run src/simulation_engine/simulationEngine.test.ts src/context_keys/contextKeys.test.ts`
- `npm run build`
- `npm run format-check`
- `npm test`

## Risk
Low. This removes duplicated condition-key resolution logic and aligns normalize/type lookup behavior with `isActualContextKey`.