### PR TITLE
fix: handle boundary implicit deny in resource pattern mode

### DIFF
--- a/src/simulation_engine/simulationEngine.ts
+++ b/src/simulation_engine/simulationEngine.ts
@@ -551,7 +551,10 @@ export async function runSimulation(
         resourceType: resourceType.key,
         resourcePattern: resourceArn
       })
-    } else {
+    } else if (exactPatternResult.result !== 'ImplicitlyDenied') {
+      // If the requested pattern is implicitly denied, narrower overlapping policy patterns cannot
+      // make the overall request allowed because exact-pattern evaluation already considers any
+      // overlapping identity, resource, and guardrail policy statements.
       let resourceStrings = [simulation.request.resource.resource]
       const identityResourceStrings = getMatchingResourceStringsForPolicies(
         identityPoliciesThatGrantAccess,

--- a/src/simulation_engine/simulationEngineIntegrationTests/contextKeys/conditionKeys.json
+++ b/src/simulation_engine/simulationEngineIntegrationTests/contextKeys/conditionKeys.json
@@ -90,13 +90,7 @@
     },
     "simulationOptions": {},
     "expected": {
-      "results": [
-        {
-          "resourceType": "object",
-          "resourcePattern": "arn:aws:s3:::examplebucket/conditional/*",
-          "result": "ImplicitlyDenied"
-        }
-      ],
+      "results": [],
       "overallResult": "ImplicitlyDenied",
       "resultType": "wildcard"
     }

--- a/src/simulation_engine/simulationEngineIntegrationTests/permissionBoundaries/exactPatternImplicitDenyRisks.json
+++ b/src/simulation_engine/simulationEngineIntegrationTests/permissionBoundaries/exactPatternImplicitDenyRisks.json
@@ -1,20 +1,17 @@
 [
   {
-    "name": "permission boundary blocks one pattern",
+    "name": "same-account direct resource policy allow outside permission boundary remains allowed",
     "simulation": {
       "identityPolicies": [
         {
-          "name": "id-allow",
+          "name": "id-allow-unrelated",
           "policy": {
             "Version": "2012-10-17",
             "Statement": [
               {
                 "Effect": "Allow",
                 "Action": "s3:GetObject",
-                "Resource": [
-                  "arn:aws:s3:::examplebucket/public/*",
-                  "arn:aws:s3:::examplebucket/private/*"
-                ]
+                "Resource": "arn:aws:s3:::allowed-example-bucket/*"
               }
             ]
           }
@@ -31,84 +28,27 @@
               {
                 "Effect": "Allow",
                 "Action": "s3:GetObject",
-                "Resource": "arn:aws:s3:::examplebucket/public/*"
+                "Resource": "arn:aws:s3:::allowed-example-bucket/*"
               }
             ]
           }
         }
       ],
-      "resourcePolicy": null,
+      "resourcePolicy": {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Principal": "arn:aws:iam::123456789012:user/ExampleUser",
+            "Action": "s3:GetObject",
+            "Resource": "arn:aws:s3:::resource-policy-example-bucket/*"
+          }
+        ]
+      },
       "request": {
         "action": "s3:GetObject",
         "resource": {
-          "resource": "arn:aws:s3:::examplebucket/*",
-          "accountId": "123456789012"
-        },
-        "principal": "arn:aws:iam::123456789012:user/Alice",
-        "contextVariables": {}
-      }
-    },
-    "simulationOptions": {},
-    "expected": {
-      "results": [
-        {
-          "resourceType": "object",
-          "resourcePattern": "arn:aws:s3:::examplebucket/public/*",
-          "result": "Allowed"
-        },
-        {
-          "resourceType": "object",
-          "resourcePattern": "arn:aws:s3:::examplebucket/private/*",
-          "result": "ImplicitlyDenied"
-        }
-      ],
-      "overallResult": "Allowed",
-      "resultType": "wildcard"
-    }
-  },
-  {
-    "name": "permission boundary implicitly denies broad identity allow for requested S3 object pattern outside boundary",
-    "simulation": {
-      "identityPolicies": [
-        {
-          "name": "id-allow",
-          "policy": {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"],
-                "Resource": "*"
-              }
-            ]
-          }
-        }
-      ],
-      "serviceControlPolicies": [],
-      "resourceControlPolicies": [],
-      "permissionBoundaryPolicies": [
-        {
-          "name": "boundary",
-          "policy": {
-            "Version": "2012-10-17",
-            "Statement": [
-              {
-                "Effect": "Allow",
-                "Action": ["s3:GetObject", "s3:PutObject", "s3:DeleteObject", "s3:ListBucket"],
-                "Resource": [
-                  "arn:aws:s3:::allowed-example-bucket",
-                  "arn:aws:s3:::allowed-example-bucket/*"
-                ]
-              }
-            ]
-          }
-        }
-      ],
-      "resourcePolicy": null,
-      "request": {
-        "action": "s3:GetObject",
-        "resource": {
-          "resource": "arn:aws:s3:::blocked-example-bucket/*",
+          "resource": "arn:aws:s3:::resource-policy-example-bucket/*",
           "accountId": "123456789012"
         },
         "principal": "arn:aws:iam::123456789012:user/ExampleUser",
@@ -117,8 +57,81 @@
     },
     "simulationOptions": {},
     "expected": {
-      "results": [],
-      "overallResult": "ImplicitlyDenied",
+      "results": [
+        {
+          "resourceType": "object",
+          "resourcePattern": "arn:aws:s3:::resource-policy-example-bucket/*",
+          "result": "Allowed"
+        }
+      ],
+      "overallResult": "Allowed",
+      "resultType": "wildcard"
+    }
+  },
+  {
+    "name": "narrow identity allow is still evaluated when another policy pattern is implicitly denied",
+    "simulation": {
+      "identityPolicies": [
+        {
+          "name": "id-allow-mixed",
+          "policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": [
+                  "arn:aws:s3:::mixed-example-bucket/public/*",
+                  "arn:aws:s3:::mixed-example-bucket/private/*"
+                ]
+              }
+            ]
+          }
+        }
+      ],
+      "serviceControlPolicies": [],
+      "resourceControlPolicies": [],
+      "permissionBoundaryPolicies": [
+        {
+          "name": "boundary",
+          "policy": {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::mixed-example-bucket/public/*"
+              }
+            ]
+          }
+        }
+      ],
+      "resourcePolicy": null,
+      "request": {
+        "action": "s3:GetObject",
+        "resource": {
+          "resource": "arn:aws:s3:::mixed-example-bucket/*",
+          "accountId": "123456789012"
+        },
+        "principal": "arn:aws:iam::123456789012:user/ExampleUser",
+        "contextVariables": {}
+      }
+    },
+    "simulationOptions": {},
+    "expected": {
+      "results": [
+        {
+          "resourceType": "object",
+          "resourcePattern": "arn:aws:s3:::mixed-example-bucket/public/*",
+          "result": "Allowed"
+        },
+        {
+          "resourceType": "object",
+          "resourcePattern": "arn:aws:s3:::mixed-example-bucket/private/*",
+          "result": "ImplicitlyDenied"
+        }
+      ],
+      "overallResult": "Allowed",
       "resultType": "wildcard"
     }
   }

--- a/src/simulation_engine/simulationEngineIntegrationTests/policyTypes/noPrincipalElement.json
+++ b/src/simulation_engine/simulationEngineIntegrationTests/policyTypes/noPrincipalElement.json
@@ -27,13 +27,7 @@
     },
     "simulationOptions": {},
     "expected": {
-      "results": [
-        {
-          "resourceType": "object",
-          "resourcePattern": "arn:aws:s3:::examplebucket/private/*",
-          "result": "ImplicitlyDenied"
-        }
-      ],
+      "results": [],
       "overallResult": "ImplicitlyDenied",
       "resultType": "wildcard"
     }


### PR DESCRIPTION
## Summary
- avoid expanding wildcard resource-pattern simulations when the exact requested pattern is implicitly denied
- add a regression case for broad S3 identity allow blocked by a narrower permission boundary
- update accepted implicit-deny detail expectations and add guardrail risk coverage for resource-policy bypass and mixed boundary results
