### PR TITLE
feat: add discovery allowed condition expressions

### DIFF
--- a/src/analysis/allowedConditions.test.ts
+++ b/src/analysis/allowedConditions.test.ts
@@ -1,0 +1,780 @@
+import { loadPolicy } from '@cloud-copilot/iam-policy'
+import { describe, expect, it } from 'vitest'
+import { and, denyStatementEscapeExpression, invertCondition, or } from './allowedConditions.js'
+import type { AllowedConditionExpression, AllowedConditionSource } from '../evaluate.js'
+import type { StatementAnalysis } from '../StatementAnalysis.js'
+
+const source: AllowedConditionSource = {
+  policyType: 'identity',
+  effect: 'Deny',
+  policyIdentifier: 'test-policy',
+  statementIndex: 1
+}
+
+const sourceVpcCondition: AllowedConditionExpression = {
+  conditionType: 'condition',
+  op: 'StringEquals',
+  key: 'aws:SourceVpc',
+  values: ['vpc-123'],
+  sources: [source]
+}
+
+const sourceIpCondition: AllowedConditionExpression = {
+  conditionType: 'condition',
+  op: 'IpAddress',
+  key: 'aws:SourceIp',
+  values: ['203.0.113.0/24'],
+  sources: [source]
+}
+
+const sourceVpceCondition: AllowedConditionExpression = {
+  conditionType: 'condition',
+  op: 'StringEquals',
+  key: 'aws:SourceVpce',
+  values: ['vpce-123'],
+  sources: [source]
+}
+
+function conditionFor(operator: string, key: string, values: string | string[]) {
+  const policy = loadPolicy(
+    {
+      Version: '2012-10-17',
+      Statement: [
+        {
+          Effect: 'Deny',
+          Action: '*',
+          Resource: '*',
+          Condition: { [operator]: { [key]: values } }
+        }
+      ]
+    },
+    { name: 'test-policy' }
+  )
+  return policy.statements()[0].conditions()[0]
+}
+
+function statementWithIgnoredConditions(
+  conditions: ReturnType<typeof conditionFor>[]
+): StatementAnalysis {
+  const statement = loadPolicy(
+    {
+      Version: '2012-10-17',
+      Statement: [{ Effect: 'Deny', Action: '*', Resource: '*' }]
+    },
+    { name: 'test-policy' }
+  ).statements()[0]
+
+  return {
+    policyId: 'test-policy',
+    statement,
+    resourceMatch: true,
+    actionMatch: true,
+    principalMatch: 'Match',
+    conditionMatch: 'NoMatch',
+    ignoredConditions: conditions,
+    explain: {
+      effect: 'Deny',
+      identifier: '1',
+      matches: false,
+      actionMatch: true,
+      principalMatch: 'Match',
+      resourceMatch: true,
+      conditionMatch: false
+    }
+  }
+}
+
+function invertedCondition(op: string, key: string, values: string[]): AllowedConditionExpression {
+  return {
+    conditionType: 'condition',
+    op,
+    key,
+    values,
+    sources: [source],
+    inverted: true
+  }
+}
+
+const expressionHelperTests: {
+  name: string
+  expression: () => AllowedConditionExpression
+  expected: AllowedConditionExpression
+}[] = [
+  {
+    name: 'simplifies OR with an unconditional branch to always',
+    expression: () => or([sourceVpcCondition, { conditionType: 'always' }]),
+    expected: { conditionType: 'always' }
+  },
+  {
+    name: 'simplifies AND with a never branch to never',
+    expression: () =>
+      and([
+        sourceVpcCondition,
+        { conditionType: 'never', reason: 'explicitDenyWithoutConditions' }
+      ]),
+    expected: { conditionType: 'never', reason: 'explicitDenyWithoutConditions' }
+  },
+  {
+    name: 'flattens nested AND groups',
+    expression: () => and([and([sourceVpcCondition, sourceIpCondition]), sourceVpceCondition]),
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [sourceVpcCondition, sourceIpCondition, sourceVpceCondition]
+    }
+  },
+  {
+    name: 'flattens nested OR groups',
+    expression: () => or([or([sourceVpcCondition, sourceIpCondition]), sourceVpceCondition]),
+    expected: {
+      conditionType: 'group',
+      operator: 'or',
+      conditions: [sourceVpcCondition, sourceIpCondition, sourceVpceCondition]
+    }
+  }
+]
+
+describe('allowed condition expression helpers', () => {
+  for (const testCase of expressionHelperTests) {
+    it(testCase.name, () => {
+      //Given expression inputs defined by the test case
+      //When the expression is built and simplified
+      const result = testCase.expression()
+
+      //Then the result should match the expected simplified expression
+      expect(result).toEqual(testCase.expected)
+    })
+  }
+})
+
+const invertConditionTests: {
+  name: string
+  op: string
+  key: string
+  values: string[]
+  expected: AllowedConditionExpression
+}[] = [
+  {
+    name: 'inverts StringEquals to StringNotEquals with the same values',
+    op: 'StringEquals',
+    key: 'aws:ExampleKey',
+    values: ['expected'],
+    expected: invertedCondition('StringNotEquals', 'aws:ExampleKey', ['expected'])
+  },
+  {
+    name: 'inverts StringNotEquals to StringEquals with the same values',
+    op: 'StringNotEquals',
+    key: 'aws:ExampleKey',
+    values: ['expected'],
+    expected: invertedCondition('StringEquals', 'aws:ExampleKey', ['expected'])
+  },
+  {
+    name: 'inverts StringEqualsIgnoreCase to StringNotEqualsIgnoreCase with the same values',
+    op: 'StringEqualsIgnoreCase',
+    key: 'aws:ExampleKey',
+    values: ['Expected'],
+    expected: invertedCondition('StringNotEqualsIgnoreCase', 'aws:ExampleKey', ['Expected'])
+  },
+  {
+    name: 'inverts StringNotEqualsIgnoreCase to StringEqualsIgnoreCase with the same values',
+    op: 'StringNotEqualsIgnoreCase',
+    key: 'aws:ExampleKey',
+    values: ['Expected'],
+    expected: invertedCondition('StringEqualsIgnoreCase', 'aws:ExampleKey', ['Expected'])
+  },
+  {
+    name: 'inverts StringLike to StringNotLike with the same values',
+    op: 'StringLike',
+    key: 'aws:ExampleKey',
+    values: ['prod-*'],
+    expected: invertedCondition('StringNotLike', 'aws:ExampleKey', ['prod-*'])
+  },
+  {
+    name: 'inverts StringNotLike to StringLike with the same values',
+    op: 'StringNotLike',
+    key: 'aws:ExampleKey',
+    values: ['prod-*'],
+    expected: invertedCondition('StringLike', 'aws:ExampleKey', ['prod-*'])
+  },
+  {
+    name: 'inverts ArnEquals to ArnNotEquals with the same values',
+    op: 'ArnEquals',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::123456789012:role/Admin'],
+    expected: invertedCondition('ArnNotEquals', 'aws:PrincipalArn', [
+      'arn:aws:iam::123456789012:role/Admin'
+    ])
+  },
+  {
+    name: 'inverts ArnNotEquals to ArnEquals with the same values',
+    op: 'ArnNotEquals',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::123456789012:role/Admin'],
+    expected: invertedCondition('ArnEquals', 'aws:PrincipalArn', [
+      'arn:aws:iam::123456789012:role/Admin'
+    ])
+  },
+  {
+    name: 'inverts ArnLike to ArnNotLike with the same values',
+    op: 'ArnLike',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::*:role/Admin*'],
+    expected: invertedCondition('ArnNotLike', 'aws:PrincipalArn', ['arn:aws:iam::*:role/Admin*'])
+  },
+  {
+    name: 'inverts ArnNotLike to ArnLike with the same values',
+    op: 'ArnNotLike',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::*:role/Admin*'],
+    expected: invertedCondition('ArnLike', 'aws:PrincipalArn', ['arn:aws:iam::*:role/Admin*'])
+  },
+  {
+    name: 'inverts NumericEquals to NumericNotEquals with the same values',
+    op: 'NumericEquals',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expected: invertedCondition('NumericNotEquals', 's3:TlsVersion', ['1.2'])
+  },
+  {
+    name: 'inverts NumericNotEquals to NumericEquals with the same values',
+    op: 'NumericNotEquals',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expected: invertedCondition('NumericEquals', 's3:TlsVersion', ['1.2'])
+  },
+  {
+    name: 'inverts NumericLessThan to NumericGreaterThanEquals with the same values',
+    op: 'NumericLessThan',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expected: invertedCondition('NumericGreaterThanEquals', 's3:TlsVersion', ['1.2'])
+  },
+  {
+    name: 'inverts NumericLessThanEquals to NumericGreaterThan with the same values',
+    op: 'NumericLessThanEquals',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expected: invertedCondition('NumericGreaterThan', 's3:TlsVersion', ['1.2'])
+  },
+  {
+    name: 'inverts NumericGreaterThan to NumericLessThanEquals with the same values',
+    op: 'NumericGreaterThan',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expected: invertedCondition('NumericLessThanEquals', 's3:TlsVersion', ['1.2'])
+  },
+  {
+    name: 'inverts NumericGreaterThanEquals to NumericLessThan with the same values',
+    op: 'NumericGreaterThanEquals',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expected: invertedCondition('NumericLessThan', 's3:TlsVersion', ['1.2'])
+  },
+  {
+    name: 'inverts DateEquals to DateNotEquals with the same values',
+    op: 'DateEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expected: invertedCondition('DateNotEquals', 'aws:CurrentTime', ['2024-01-01T00:00:00Z'])
+  },
+  {
+    name: 'inverts DateNotEquals to DateEquals with the same values',
+    op: 'DateNotEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expected: invertedCondition('DateEquals', 'aws:CurrentTime', ['2024-01-01T00:00:00Z'])
+  },
+  {
+    name: 'inverts DateLessThan to DateGreaterThanEquals with the same values',
+    op: 'DateLessThan',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expected: invertedCondition('DateGreaterThanEquals', 'aws:CurrentTime', [
+      '2024-01-01T00:00:00Z'
+    ])
+  },
+  {
+    name: 'inverts DateLessThanEquals to DateGreaterThan with the same values',
+    op: 'DateLessThanEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expected: invertedCondition('DateGreaterThan', 'aws:CurrentTime', ['2024-01-01T00:00:00Z'])
+  },
+  {
+    name: 'inverts DateGreaterThan to DateLessThanEquals with the same values',
+    op: 'DateGreaterThan',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expected: invertedCondition('DateLessThanEquals', 'aws:CurrentTime', ['2024-01-01T00:00:00Z'])
+  },
+  {
+    name: 'inverts DateGreaterThanEquals to DateLessThan with the same values',
+    op: 'DateGreaterThanEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expected: invertedCondition('DateLessThan', 'aws:CurrentTime', ['2024-01-01T00:00:00Z'])
+  },
+  {
+    name: 'inverts IpAddress to NotIpAddress with the same values',
+    op: 'IpAddress',
+    key: 'aws:SourceIp',
+    values: ['192.0.2.0/24'],
+    expected: invertedCondition('NotIpAddress', 'aws:SourceIp', ['192.0.2.0/24'])
+  },
+  {
+    name: 'inverts NotIpAddress to IpAddress with the same values',
+    op: 'NotIpAddress',
+    key: 'aws:SourceIp',
+    values: ['192.0.2.0/24'],
+    expected: invertedCondition('IpAddress', 'aws:SourceIp', ['192.0.2.0/24'])
+  },
+  {
+    name: 'inverts BinaryEquals to synthetic BinaryNotEquals with the same values',
+    op: 'BinaryEquals',
+    key: 'aws:BinaryKey',
+    values: ['AAAA'],
+    expected: invertedCondition('BinaryNotEquals', 'aws:BinaryKey', ['AAAA'])
+  },
+  {
+    name: 'inverts synthetic BinaryNotEquals to BinaryEquals with the same values',
+    op: 'BinaryNotEquals',
+    key: 'aws:BinaryKey',
+    values: ['AAAA'],
+    expected: invertedCondition('BinaryEquals', 'aws:BinaryKey', ['AAAA'])
+  },
+  {
+    name: 'inverts Bool true to Bool false',
+    op: 'Bool',
+    key: 'aws:SecureTransport',
+    values: ['true'],
+    expected: invertedCondition('Bool', 'aws:SecureTransport', ['false'])
+  },
+  {
+    name: 'inverts Null true to Null false',
+    op: 'Null',
+    key: 'aws:SourceVpc',
+    values: ['true'],
+    expected: invertedCondition('Null', 'aws:SourceVpc', ['false'])
+  },
+  {
+    name: 'inverts StringEqualsIfExists to present key and StringNotEquals with the same values',
+    op: 'StringEqualsIfExists',
+    key: 'aws:SourceVpc',
+    values: ['vpc-123'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceVpc', ['false']),
+        invertedCondition('StringNotEquals', 'aws:SourceVpc', ['vpc-123'])
+      ]
+    }
+  },
+  {
+    name: 'inverts StringNotEqualsIfExists to StringEquals with the same value because the null check is redundant',
+    op: 'StringNotEqualsIfExists',
+    key: 'aws:SourceVpc',
+    values: ['vpc-123'],
+    expected: invertedCondition('StringEquals', 'aws:SourceVpc', ['vpc-123'])
+  },
+  {
+    name: 'inverts StringNotEqualsIfExists to StringEquals with multiple values because the null check is redundant',
+    op: 'StringNotEqualsIfExists',
+    key: 'aws:SourceVpc',
+    values: ['vpc-123', 'vpc-456'],
+    expected: invertedCondition('StringEquals', 'aws:SourceVpc', ['vpc-123', 'vpc-456'])
+  },
+  {
+    name: 'inverts ForAllValues:StringEquals to present key and ForAnyValue:StringNotEquals',
+    op: 'ForAllValues:StringEquals',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['false']),
+        invertedCondition('ForAnyValue:StringNotEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAnyValue:StringEquals to missing key or ForAllValues:StringNotEquals',
+    op: 'ForAnyValue:StringEquals',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'or',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['true']),
+        invertedCondition('ForAllValues:StringNotEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAllValues:StringNotEquals to present key and ForAnyValue:StringEquals',
+    op: 'ForAllValues:StringNotEquals',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['false']),
+        invertedCondition('ForAnyValue:StringEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAnyValue:StringNotEquals to missing key or ForAllValues:StringEquals',
+    op: 'ForAnyValue:StringNotEquals',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'or',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['true']),
+        invertedCondition('ForAllValues:StringEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAllValues:ArnLike to present key and ForAnyValue:ArnNotLike',
+    op: 'ForAllValues:ArnLike',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::*:role/Admin*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:PrincipalArn', ['false']),
+        invertedCondition('ForAnyValue:ArnNotLike', 'aws:PrincipalArn', [
+          'arn:aws:iam::*:role/Admin*'
+        ])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAnyValue:ArnLike to missing key or ForAllValues:ArnNotLike',
+    op: 'ForAnyValue:ArnLike',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::*:role/Admin*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'or',
+      conditions: [
+        invertedCondition('Null', 'aws:PrincipalArn', ['true']),
+        invertedCondition('ForAllValues:ArnNotLike', 'aws:PrincipalArn', [
+          'arn:aws:iam::*:role/Admin*'
+        ])
+      ]
+    }
+  },
+  {
+    name: 'preserves multiple values when inverting ForAllValues:StringEquals',
+    op: 'ForAllValues:StringEquals',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*', 'o-2/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['false']),
+        invertedCondition('ForAnyValue:StringNotEquals', 'aws:SourceOrgPaths', ['o-1/*', 'o-2/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAllValues:StringEqualsIfExists without duplicating present-key requirement',
+    op: 'ForAllValues:StringEqualsIfExists',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['false']),
+        invertedCondition('ForAnyValue:StringNotEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAnyValue:StringEqualsIfExists with present-key requirement around the ForAnyValue inverse',
+    op: 'ForAnyValue:StringEqualsIfExists',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['false']),
+        {
+          conditionType: 'group',
+          operator: 'or',
+          conditions: [
+            invertedCondition('Null', 'aws:SourceOrgPaths', ['true']),
+            invertedCondition('ForAllValues:StringNotEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+          ]
+        }
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAllValues:StringNotEqualsIfExists without adding a redundant present-key requirement',
+    op: 'ForAllValues:StringNotEqualsIfExists',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'and',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['false']),
+        invertedCondition('ForAnyValue:StringEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  },
+  {
+    name: 'inverts ForAnyValue:StringNotEqualsIfExists without adding a redundant present-key requirement',
+    op: 'ForAnyValue:StringNotEqualsIfExists',
+    key: 'aws:SourceOrgPaths',
+    values: ['o-1/*'],
+    expected: {
+      conditionType: 'group',
+      operator: 'or',
+      conditions: [
+        invertedCondition('Null', 'aws:SourceOrgPaths', ['true']),
+        invertedCondition('ForAllValues:StringEquals', 'aws:SourceOrgPaths', ['o-1/*'])
+      ]
+    }
+  }
+]
+
+const singleValueIfExistsInversionTests: {
+  op: string
+  key: string
+  values: string[]
+  expectedOp: string
+  expectedValues?: string[]
+}[] = [
+  {
+    op: 'StringEquals',
+    key: 'aws:ExampleKey',
+    values: ['expected'],
+    expectedOp: 'StringNotEquals'
+  },
+  {
+    op: 'StringNotEquals',
+    key: 'aws:ExampleKey',
+    values: ['expected'],
+    expectedOp: 'StringEquals'
+  },
+  {
+    op: 'StringEqualsIgnoreCase',
+    key: 'aws:ExampleKey',
+    values: ['Expected'],
+    expectedOp: 'StringNotEqualsIgnoreCase'
+  },
+  {
+    op: 'StringNotEqualsIgnoreCase',
+    key: 'aws:ExampleKey',
+    values: ['Expected'],
+    expectedOp: 'StringEqualsIgnoreCase'
+  },
+  { op: 'StringLike', key: 'aws:ExampleKey', values: ['prod-*'], expectedOp: 'StringNotLike' },
+  { op: 'StringNotLike', key: 'aws:ExampleKey', values: ['prod-*'], expectedOp: 'StringLike' },
+  {
+    op: 'ArnEquals',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::123456789012:role/Admin'],
+    expectedOp: 'ArnNotEquals'
+  },
+  {
+    op: 'ArnNotEquals',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::123456789012:role/Admin'],
+    expectedOp: 'ArnEquals'
+  },
+  {
+    op: 'ArnLike',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::*:role/Admin*'],
+    expectedOp: 'ArnNotLike'
+  },
+  {
+    op: 'ArnNotLike',
+    key: 'aws:PrincipalArn',
+    values: ['arn:aws:iam::*:role/Admin*'],
+    expectedOp: 'ArnLike'
+  },
+  { op: 'NumericEquals', key: 's3:TlsVersion', values: ['1.2'], expectedOp: 'NumericNotEquals' },
+  { op: 'NumericNotEquals', key: 's3:TlsVersion', values: ['1.2'], expectedOp: 'NumericEquals' },
+  {
+    op: 'NumericLessThan',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expectedOp: 'NumericGreaterThanEquals'
+  },
+  {
+    op: 'NumericLessThanEquals',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expectedOp: 'NumericGreaterThan'
+  },
+  {
+    op: 'NumericGreaterThan',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expectedOp: 'NumericLessThanEquals'
+  },
+  {
+    op: 'NumericGreaterThanEquals',
+    key: 's3:TlsVersion',
+    values: ['1.2'],
+    expectedOp: 'NumericLessThan'
+  },
+  {
+    op: 'DateEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expectedOp: 'DateNotEquals'
+  },
+  {
+    op: 'DateNotEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expectedOp: 'DateEquals'
+  },
+  {
+    op: 'DateLessThan',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expectedOp: 'DateGreaterThanEquals'
+  },
+  {
+    op: 'DateLessThanEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expectedOp: 'DateGreaterThan'
+  },
+  {
+    op: 'DateGreaterThan',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expectedOp: 'DateLessThanEquals'
+  },
+  {
+    op: 'DateGreaterThanEquals',
+    key: 'aws:CurrentTime',
+    values: ['2024-01-01T00:00:00Z'],
+    expectedOp: 'DateLessThan'
+  },
+  { op: 'IpAddress', key: 'aws:SourceIp', values: ['192.0.2.0/24'], expectedOp: 'NotIpAddress' },
+  { op: 'NotIpAddress', key: 'aws:SourceIp', values: ['192.0.2.0/24'], expectedOp: 'IpAddress' },
+  { op: 'BinaryEquals', key: 'aws:BinaryKey', values: ['AAAA'], expectedOp: 'BinaryNotEquals' },
+  { op: 'BinaryNotEquals', key: 'aws:BinaryKey', values: ['AAAA'], expectedOp: 'BinaryEquals' },
+  {
+    op: 'Bool',
+    key: 'aws:SecureTransport',
+    values: ['true'],
+    expectedOp: 'Bool',
+    expectedValues: ['false']
+  }
+]
+
+function negativeConditionOperatorMatchesMissingKeys(op: string): boolean {
+  return new Set([
+    'StringNotEquals',
+    'StringNotEqualsIgnoreCase',
+    'StringNotLike',
+    'ArnNotEquals',
+    'ArnNotLike',
+    'NumericNotEquals',
+    'DateNotEquals',
+    'NotIpAddress',
+    'BinaryNotEquals'
+  ]).has(op)
+}
+
+invertConditionTests.push(
+  ...singleValueIfExistsInversionTests.map((testCase) => {
+    const invertedBase = invertedCondition(
+      testCase.expectedOp,
+      testCase.key,
+      testCase.expectedValues ?? testCase.values
+    )
+    return {
+      name: negativeConditionOperatorMatchesMissingKeys(testCase.op)
+        ? `inverts ${testCase.op}IfExists to ${testCase.expectedOp} without a redundant null check`
+        : `inverts ${testCase.op}IfExists to present key and ${testCase.expectedOp} with expected values`,
+      op: `${testCase.op}IfExists`,
+      key: testCase.key,
+      values: testCase.values,
+      expected: negativeConditionOperatorMatchesMissingKeys(testCase.op)
+        ? invertedBase
+        : {
+            conditionType: 'group' as const,
+            operator: 'and' as const,
+            conditions: [invertedCondition('Null', testCase.key, ['false']), invertedBase]
+          }
+    }
+  })
+)
+
+describe('invertCondition', () => {
+  for (const testCase of invertConditionTests) {
+    it(testCase.name, () => {
+      //Given a condition using the operator and values from the test case
+      const condition = conditionFor(testCase.op, testCase.key, testCase.values)
+
+      //When the condition is inverted
+      const result = invertCondition(condition, source)
+
+      //Then the result should include the expected inverted operators and values
+      expect(result).toEqual(testCase.expected)
+    })
+  }
+})
+
+const denyStatementEscapeTests: {
+  name: string
+  conditions: ReturnType<typeof conditionFor>[]
+  expected: AllowedConditionExpression
+}[] = [
+  {
+    name: 'inverts multiple deny conditions as an OR expression showing both inverted operators and values',
+    conditions: [
+      conditionFor('StringEquals', 'aws:SourceVpc', 'vpc-123'),
+      conditionFor('IpAddress', 'aws:SourceIp', '192.0.2.0/24')
+    ],
+    expected: {
+      conditionType: 'group',
+      operator: 'or',
+      conditions: [
+        invertedCondition('StringNotEquals', 'aws:SourceVpc', ['vpc-123']),
+        invertedCondition('NotIpAddress', 'aws:SourceIp', ['192.0.2.0/24'])
+      ]
+    }
+  },
+  {
+    name: 'represents a conditionless deny as never allowed',
+    conditions: [],
+    expected: { conditionType: 'never', reason: 'explicitDenyWithoutConditions' }
+  }
+]
+
+describe('denyStatementEscapeExpression', () => {
+  for (const testCase of denyStatementEscapeTests) {
+    it(testCase.name, () => {
+      //Given a deny statement with ignored conditions from the test case
+      const statement = statementWithIgnoredConditions(testCase.conditions)
+
+      //When the deny statement is converted to an escape expression
+      const result = denyStatementEscapeExpression(statement, 'identity')
+
+      //Then the result should match the expected inverted expression
+      expect(result).toEqual(testCase.expected)
+    })
+  }
+})

--- a/src/analysis/allowedConditions.ts
+++ b/src/analysis/allowedConditions.ts
@@ -1,0 +1,554 @@
+import { type Condition } from '@cloud-copilot/iam-policy'
+import {
+  type AllowedConditionExpression,
+  type AllowedConditionLeaf,
+  type AllowedConditionSource,
+  type AllowedSessionNameCondition,
+  type IdentityAnalysis,
+  type RcpAnalysis,
+  type ResourceAnalysis,
+  type ScpAnalysis
+} from '../evaluate.js'
+import { type StatementAnalysis } from '../StatementAnalysis.js'
+
+/**
+ * Convert a statement's ignored allow-side conditions to an expression.
+ *
+ * @param statement the statement analysis to convert
+ * @param policyType the policy family containing the statement
+ * @param orgIdentifier the organization identifier for control-policy statements
+ * @returns an expression for the statement's ignored conditions
+ */
+export function allowStatementExpression(
+  statement: StatementAnalysis,
+  policyType: AllowedConditionSource['policyType'],
+  orgIdentifier?: string
+): AllowedConditionExpression {
+  return statementConditionExpression(statement, policyType, false, orgIdentifier)
+}
+
+/**
+ * Convert a statement's ignored deny-side conditions to an expression that avoids the deny.
+ *
+ * @param statement the statement analysis to convert
+ * @param policyType the policy family containing the statement
+ * @param orgIdentifier the organization identifier for control-policy statements
+ * @returns an expression that must hold to avoid the deny
+ */
+export function denyStatementEscapeExpression(
+  statement: StatementAnalysis,
+  policyType: AllowedConditionSource['policyType'],
+  orgIdentifier?: string
+): AllowedConditionExpression {
+  if (!statement.ignoredConditions || statement.ignoredConditions.length === 0) {
+    return never('explicitDenyWithoutConditions')
+  }
+
+  const source = sourceForStatement(statement, policyType, orgIdentifier)
+  return or(statement.ignoredConditions.map((condition) => invertCondition(condition, source)))
+}
+
+/**
+ * Invert a single IAM condition into an allowed-condition expression.
+ *
+ * @param condition the condition to invert
+ * @param source source metadata for the condition
+ * @returns the expression that satisfies the logical complement of the condition
+ */
+export function invertCondition(
+  condition: Condition,
+  source: AllowedConditionSource
+): AllowedConditionExpression {
+  const op = condition.operation().value()
+  const key = condition.conditionKey()
+  const values = condition.conditionValues()
+  return invertConditionParts(op, key, values, source)
+}
+
+/**
+ * Combine condition expressions with AND semantics and simplify identity/absorbing values.
+ *
+ * @param expressions the expressions to combine
+ * @returns a simplified expression
+ */
+export function and(expressions: AllowedConditionExpression[]): AllowedConditionExpression {
+  const children = expressions.map((expr) => simplify(expr))
+  if (children.some((expr) => expr.conditionType === 'never')) {
+    return children.find((expr) => expr.conditionType === 'never')!
+  }
+  const withoutAlways = dedupe(
+    children
+      .filter((expr) => expr.conditionType !== 'always')
+      .flatMap((expr) =>
+        expr.conditionType === 'group' && expr.operator === 'and' ? expr.conditions : [expr]
+      )
+  )
+  if (withoutAlways.length === 0) {
+    return always()
+  }
+  if (withoutAlways.length === 1) {
+    return withoutAlways[0]
+  }
+  return { conditionType: 'group', operator: 'and', conditions: withoutAlways }
+}
+
+/**
+ * Combine condition expressions with OR semantics and simplify identity/absorbing values.
+ *
+ * @param expressions the expressions to combine
+ * @returns a simplified expression
+ */
+export function or(expressions: AllowedConditionExpression[]): AllowedConditionExpression {
+  const children = expressions.map((expr) => simplify(expr))
+  if (children.some((expr) => expr.conditionType === 'always')) {
+    return always()
+  }
+  const withoutNever = dedupe(
+    children
+      .filter((expr) => expr.conditionType !== 'never')
+      .flatMap((expr) =>
+        expr.conditionType === 'group' && expr.operator === 'or' ? expr.conditions : [expr]
+      )
+  )
+  if (withoutNever.length === 0) {
+    return never('noApplicableAllow')
+  }
+  if (withoutNever.length === 1) {
+    return withoutNever[0]
+  }
+  return { conditionType: 'group', operator: 'or', conditions: withoutNever }
+}
+
+export function allowedConditionOutput(
+  expression: AllowedConditionExpression,
+  simulationMode: string,
+  result: string
+): AllowedConditionExpression | undefined {
+  if (simulationMode !== 'Discovery' || result !== 'Allowed') {
+    return undefined
+  }
+  return publicExpression(expression)
+}
+
+export function sessionPolicyExpression(
+  analysis: IdentityAnalysis | undefined,
+  sessionPolicyPresent: boolean
+): AllowedConditionExpression {
+  return sessionPolicyPresent ? identityAllowExpression(analysis, 'session') : always()
+}
+
+export function identityPolicyExpression(
+  analysis: IdentityAnalysis | undefined
+): AllowedConditionExpression {
+  return identityAllowExpression(analysis, 'identity')
+}
+
+export function permissionBoundaryExpression(
+  analysis: IdentityAnalysis | undefined
+): AllowedConditionExpression {
+  return identityAllowExpression(analysis, 'permissionBoundary')
+}
+
+export function endpointPolicyExpression(
+  analysis: IdentityAnalysis | undefined
+): AllowedConditionExpression {
+  return identityAllowExpression(analysis, 'endpointPolicy')
+}
+
+export function resourceAllowStatementsExpression(
+  statements: StatementAnalysis[]
+): AllowedConditionExpression {
+  return allowStatementsExpression(statements, 'resource')
+}
+
+export function allDenyEscapeExpressions(input: {
+  sessionAnalysis?: IdentityAnalysis
+  scpAnalysis?: ScpAnalysis
+  rcpAnalysis?: RcpAnalysis
+  identityAnalysis?: IdentityAnalysis
+  resourceAnalysis?: ResourceAnalysis
+  permissionBoundaryAnalysis?: IdentityAnalysis
+  endpointAnalysis?: IdentityAnalysis
+}): AllowedConditionExpression[] {
+  return [
+    ...denyEscapeExpressions(input.sessionAnalysis, 'session'),
+    ...controlPolicyDenyEscapeExpressions(input.scpAnalysis, 'scp'),
+    ...controlPolicyDenyEscapeExpressions(input.rcpAnalysis, 'rcp'),
+    ...denyEscapeExpressions(input.identityAnalysis, 'identity'),
+    ...resourceDenyEscapeExpressions(input.resourceAnalysis),
+    ...denyEscapeExpressions(input.permissionBoundaryAnalysis, 'permissionBoundary'),
+    ...denyEscapeExpressions(input.endpointAnalysis, 'endpointPolicy')
+  ]
+}
+
+function identityAllowExpression(
+  analysis: IdentityAnalysis | undefined,
+  policyType: AllowedConditionSource['policyType']
+): AllowedConditionExpression {
+  if (!analysis || analysis.result !== 'Allowed') {
+    return never('noApplicableAllow')
+  }
+  return allowStatementsExpression(analysis.allowStatements, policyType)
+}
+
+function allowStatementsExpression(
+  statements: StatementAnalysis[],
+  policyType: AllowedConditionSource['policyType']
+): AllowedConditionExpression {
+  if (statements.length === 0) {
+    return never('noApplicableAllow')
+  }
+  return or(statements.map((statement) => allowStatementExpression(statement, policyType)))
+}
+
+function denyEscapeExpressions(
+  analysis: IdentityAnalysis | undefined,
+  policyType: AllowedConditionSource['policyType']
+): AllowedConditionExpression[] {
+  return denyStatementsThatNeedEscapes(analysis).map((statement) =>
+    denyStatementEscapeExpression(statement, policyType)
+  )
+}
+
+function resourceDenyEscapeExpressions(
+  analysis: ResourceAnalysis | undefined
+): AllowedConditionExpression[] {
+  return denyStatementsThatNeedEscapes(analysis).map((statement) =>
+    denyStatementEscapeExpression(statement, 'resource')
+  )
+}
+
+function controlPolicyDenyEscapeExpressions(
+  analysis: ScpAnalysis | RcpAnalysis | undefined,
+  policyType: 'scp' | 'rcp'
+): AllowedConditionExpression[] {
+  return (analysis?.ouAnalysis ?? []).flatMap((ou) =>
+    denyStatementsThatNeedEscapes(ou).map((statement) =>
+      denyStatementEscapeExpression(statement, policyType, ou.orgIdentifier)
+    )
+  )
+}
+
+function denyStatementsThatNeedEscapes(
+  analysis:
+    { denyStatements: StatementAnalysis[]; unmatchedStatements: StatementAnalysis[] } | undefined
+): StatementAnalysis[] {
+  return [...(analysis?.denyStatements ?? []), ...(analysis?.unmatchedStatements ?? [])].filter(
+    (statement) => statement.statement.isDeny() && (statement.ignoredConditions?.length ?? 0) > 0
+  )
+}
+
+function statementConditionExpression(
+  statement: StatementAnalysis,
+  policyType: AllowedConditionSource['policyType'],
+  inverted: boolean,
+  orgIdentifier?: string
+): AllowedConditionExpression {
+  const source = sourceForStatement(statement, policyType, orgIdentifier)
+  const conditions = statement.ignoredConditions ?? []
+  const conditionExpressions: AllowedConditionExpression[] = conditions.map((condition) =>
+    conditionLeaf(condition, source, inverted)
+  )
+  const sessionExpression = sessionNameExpression(statement, source)
+  if (sessionExpression) {
+    conditionExpressions.push(sessionExpression)
+  }
+  return and(conditionExpressions)
+}
+
+function sourceForStatement(
+  statement: StatementAnalysis,
+  policyType: AllowedConditionSource['policyType'],
+  orgIdentifier?: string
+): AllowedConditionSource {
+  const sid = statement.statement.sid()
+  return {
+    policyType,
+    effect: statement.statement.effect() as 'Allow' | 'Deny',
+    policyIdentifier: statement.policyId,
+    ...(orgIdentifier ? { orgIdentifier } : {}),
+    ...(sid ? { statementId: sid } : {}),
+    statementIndex: statement.statement.index()
+  }
+}
+
+function conditionLeaf(
+  condition: Condition,
+  source: AllowedConditionSource,
+  inverted: boolean
+): AllowedConditionLeaf {
+  return {
+    conditionType: 'condition',
+    op: condition.operation().value(),
+    key: condition.conditionKey(),
+    values: condition.conditionValues(),
+    sources: [source],
+    ...(inverted ? { inverted: true as const } : {})
+  }
+}
+
+function sessionNameExpression(
+  statement: StatementAnalysis,
+  source: AllowedConditionSource
+): AllowedSessionNameCondition | undefined {
+  if (!statement.ignoredRoleSessionName) {
+    return undefined
+  }
+
+  const names = principalExplains(statement)
+    .map((explain) => sessionNameFromAssumedRoleArn(explain.principal))
+    .filter((name): name is string => name !== undefined)
+
+  if (names.length === 0) {
+    return undefined
+  }
+
+  return {
+    conditionType: 'sessionName',
+    sessionName: Array.from(new Set(names)),
+    sources: [source]
+  }
+}
+
+function principalExplains(statement: StatementAnalysis): { principal: string }[] {
+  const principals = statement.explain.principals ?? statement.explain.notPrincipals
+  if (!principals) {
+    return []
+  }
+  return Array.isArray(principals) ? principals : [principals]
+}
+
+function sessionNameFromAssumedRoleArn(arn: string): string | undefined {
+  const resource = arn.split(':').at(-1)
+  if (!resource?.startsWith('assumed-role/')) {
+    return undefined
+  }
+  return resource.split('/').at(2)
+}
+
+function invertConditionParts(
+  op: string,
+  key: string,
+  values: string[],
+  source: AllowedConditionSource
+): AllowedConditionExpression {
+  const setOperator = conditionSetOperator(op)
+  const hasIfExists = isIfExists(op)
+  const base = conditionBaseOperator(op)
+
+  if (hasIfExists) {
+    const withoutIfExists = operatorName(base, setOperator, false)
+    const invertedBase = invertConditionParts(withoutIfExists, key, values, source)
+    if (negativeConditionOperatorsMatchMissingKeys(base)) {
+      return invertedBase
+    }
+    return and([leaf('Null', key, ['false'], source), invertedBase])
+  }
+
+  if (base.toLowerCase() === 'null' || base.toLowerCase() === 'bool') {
+    return leaf(
+      invertedOperatorName(op, base, setOperator, hasIfExists),
+      key,
+      flipBooleanValues(values),
+      source
+    )
+  }
+
+  if (setOperator === 'ForAllValues') {
+    return and([
+      leaf('Null', key, ['false'], source),
+      leaf(operatorName(invertBaseOperator(base), 'ForAnyValue', false), key, values, source)
+    ])
+  }
+
+  if (setOperator === 'ForAnyValue') {
+    return or([
+      leaf('Null', key, ['true'], source),
+      leaf(operatorName(invertBaseOperator(base), 'ForAllValues', false), key, values, source)
+    ])
+  }
+
+  return leaf(invertBaseOperator(base), key, values, source)
+}
+
+function leaf(
+  op: string,
+  key: string,
+  values: string[],
+  source: AllowedConditionSource
+): AllowedConditionLeaf {
+  return {
+    conditionType: 'condition',
+    op,
+    key,
+    values,
+    sources: [source],
+    inverted: true
+  }
+}
+
+function conditionSetOperator(op: string): 'ForAllValues' | 'ForAnyValue' | undefined {
+  const prefix = op.includes(':') ? op.split(':')[0].toLowerCase() : undefined
+  if (prefix === 'forallvalues') {
+    return 'ForAllValues'
+  }
+  if (prefix === 'foranyvalue') {
+    return 'ForAnyValue'
+  }
+  return undefined
+}
+
+function conditionBaseOperator(op: string): string {
+  return op
+    .split(':')
+    .at(-1)!
+    .replace(/IfExists$/i, '')
+}
+
+function isIfExists(op: string): boolean {
+  return /IfExists$/i.test(op)
+}
+
+function invertedOperatorName(
+  originalOp: string,
+  base: string,
+  setOperator: 'ForAllValues' | 'ForAnyValue' | undefined,
+  hasIfExists: boolean
+): string {
+  if (base.toLowerCase() === 'bool' || base.toLowerCase() === 'null') {
+    return operatorName(base, setOperator, hasIfExists)
+  }
+  return originalOp
+}
+
+function negativeConditionOperatorsMatchMissingKeys(base: string): boolean {
+  return new Set([
+    'stringnotequals',
+    'stringnotequalsignorecase',
+    'stringnotlike',
+    'arnnotequals',
+    'arnnotlike',
+    'numericnotequals',
+    'datenotequals',
+    'notipaddress',
+    'binarynotequals'
+  ]).has(base.toLowerCase())
+}
+
+function operatorName(
+  base: string,
+  setOperator: 'ForAllValues' | 'ForAnyValue' | undefined,
+  ifExists: boolean
+): string {
+  const op = canonicalBaseOperator(base) + (ifExists ? 'IfExists' : '')
+  return setOperator ? `${setOperator}:${op}` : op
+}
+
+function invertBaseOperator(base: string): string {
+  const map: Record<string, string> = {
+    stringequals: 'StringNotEquals',
+    stringnotequals: 'StringEquals',
+    stringequalsignorecase: 'StringNotEqualsIgnoreCase',
+    stringnotequalsignorecase: 'StringEqualsIgnoreCase',
+    stringlike: 'StringNotLike',
+    stringnotlike: 'StringLike',
+    arnequals: 'ArnNotEquals',
+    arnnotequals: 'ArnEquals',
+    arnlike: 'ArnNotLike',
+    arnnotlike: 'ArnLike',
+    numericequals: 'NumericNotEquals',
+    numericnotequals: 'NumericEquals',
+    numericlessthan: 'NumericGreaterThanEquals',
+    numericlessthanequals: 'NumericGreaterThan',
+    numericgreaterthan: 'NumericLessThanEquals',
+    numericgreaterthanequals: 'NumericLessThan',
+    dateequals: 'DateNotEquals',
+    datenotequals: 'DateEquals',
+    datelessthan: 'DateGreaterThanEquals',
+    datelessthanequals: 'DateGreaterThan',
+    dategreaterthan: 'DateLessThanEquals',
+    dategreaterthanequals: 'DateLessThan',
+    ipaddress: 'NotIpAddress',
+    notipaddress: 'IpAddress',
+    binaryequals: 'BinaryNotEquals',
+    binarynotequals: 'BinaryEquals'
+  }
+  return map[base.toLowerCase()] ?? `Not:${base}`
+}
+
+function canonicalBaseOperator(base: string): string {
+  const canonical: Record<string, string> = {
+    stringequals: 'StringEquals',
+    stringnotequals: 'StringNotEquals',
+    stringequalsignorecase: 'StringEqualsIgnoreCase',
+    stringnotequalsignorecase: 'StringNotEqualsIgnoreCase',
+    stringlike: 'StringLike',
+    stringnotlike: 'StringNotLike',
+    arnequals: 'ArnEquals',
+    arnnotequals: 'ArnNotEquals',
+    arnlike: 'ArnLike',
+    arnnotlike: 'ArnNotLike',
+    numericequals: 'NumericEquals',
+    numericnotequals: 'NumericNotEquals',
+    numericlessthan: 'NumericLessThan',
+    numericlessthanequals: 'NumericLessThanEquals',
+    numericgreaterthan: 'NumericGreaterThan',
+    numericgreaterthanequals: 'NumericGreaterThanEquals',
+    dateequals: 'DateEquals',
+    datenotequals: 'DateNotEquals',
+    datelessthan: 'DateLessThan',
+    datelessthanequals: 'DateLessThanEquals',
+    dategreaterthan: 'DateGreaterThan',
+    dategreaterthanequals: 'DateGreaterThanEquals',
+    bool: 'Bool',
+    null: 'Null',
+    ipaddress: 'IpAddress',
+    notipaddress: 'NotIpAddress',
+    binaryequals: 'BinaryEquals',
+    binarynotequals: 'BinaryNotEquals'
+  }
+  return canonical[base.toLowerCase()] ?? base
+}
+
+function flipBooleanValues(values: string[]): string[] {
+  return values.map((value) => (value.toLowerCase() === 'true' ? 'false' : 'true'))
+}
+
+function publicExpression(
+  expression: AllowedConditionExpression
+): AllowedConditionExpression | undefined {
+  const simplified = simplify(expression)
+  return simplified.conditionType === 'always' || simplified.conditionType === 'never'
+    ? undefined
+    : simplified
+}
+
+function simplify(expression: AllowedConditionExpression): AllowedConditionExpression {
+  if (expression.conditionType !== 'group') {
+    return expression
+  }
+  return expression.operator === 'and' ? and(expression.conditions) : or(expression.conditions)
+}
+
+export function always(): AllowedConditionExpression {
+  return { conditionType: 'always' }
+}
+
+export function never(
+  reason: 'explicitDenyWithoutConditions' | 'noApplicableAllow'
+): AllowedConditionExpression {
+  return { conditionType: 'never', reason }
+}
+
+function dedupe(expressions: AllowedConditionExpression[]): AllowedConditionExpression[] {
+  const seen = new Set<string>()
+  const result: AllowedConditionExpression[] = []
+  for (const expression of expressions) {
+    const key = JSON.stringify(expression)
+    if (!seen.has(key)) {
+      seen.add(key)
+      result.push(expression)
+    }
+  }
+  return result
+}

--- a/src/core_engine/CoreSimulatorEngine.ts
+++ b/src/core_engine/CoreSimulatorEngine.ts
@@ -1,6 +1,7 @@
 import { type Policy, type Statement } from '@cloud-copilot/iam-policy'
 import { requestMatchesStatementActions } from '../action/action.js'
 import { type ConditionMatchResult, requestMatchesConditions } from '../condition/condition.js'
+import { allowStatementExpression, always, and, never, or } from '../analysis/allowedConditions.js'
 import { DiscoveryContextKeyConstraints } from '../context_keys/discoveryContextKeyConstraints.js'
 import {
   type EvaluationResult,
@@ -370,7 +371,8 @@ export function analyzeControlPolicies(
       result: 'ImplicitlyDenied',
       allowStatements: [],
       denyStatements: [],
-      unmatchedStatements: []
+      unmatchedStatements: [],
+      conditions: never('noApplicableAllow')
     }
     for (const policy of controlPolicy.policies) {
       for (const statement of policy.statements()) {
@@ -439,6 +441,18 @@ export function analyzeControlPolicies(
     } else if (ouAnalysis.allowStatements.length > 0) {
       ouAnalysis.result = 'Allowed'
     }
+
+    if (ouAnalysis.result === 'Allowed') {
+      ouAnalysis.conditions = or(
+        ouAnalysis.allowStatements.map((statement) =>
+          allowStatementExpression(
+            statement,
+            policyType as 'scp' | 'rcp',
+            controlPolicy.orgIdentifier
+          )
+        )
+      )
+    }
     analysis.push(ouAnalysis)
   }
 
@@ -453,7 +467,13 @@ export function analyzeControlPolicies(
 
   return {
     result: overallResult,
-    ouAnalysis: analysis
+    ouAnalysis: analysis,
+    conditions:
+      analysis.length === 0
+        ? always()
+        : overallResult === 'Allowed'
+          ? and(analysis.map((ou) => ou.conditions))
+          : never('noApplicableAllow')
   }
 }
 

--- a/src/core_engine/coreEngineTests/anonymous.json
+++ b/src/core_engine/coreEngineTests/anonymous.json
@@ -3,21 +3,33 @@
     "name": "anonymous implicit deny without resource policy or RCP",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
     "serviceControlPolicies": [],
     "resourceControlPolicies": [],
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   },
   {
     "name": "anonymous allowed by public resource policy without RCP",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -34,19 +46,31 @@
         }
       ]
     },
-    "expected": { "response": "Allowed" }
+    "expected": {
+      "response": "Allowed"
+    }
   },
   {
     "name": "anonymous allowed by public resource policy with default RCP",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
     "serviceControlPolicies": [],
-    "resourceControlPolicies": [{ "orgIdentifier": "o-123", "policies": [] }],
+    "resourceControlPolicies": [
+      {
+        "orgIdentifier": "o-123",
+        "policies": []
+      }
+    ],
     "resourcePolicy": {
       "Version": "2012-10-17",
       "Statement": [
@@ -58,14 +82,21 @@
         }
       ]
     },
-    "expected": { "response": "Allowed" }
+    "expected": {
+      "response": "Allowed"
+    }
   },
   {
     "name": "anonymous blocked by RCP deny",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -99,14 +130,22 @@
         }
       ]
     },
-    "expected": { "response": "ExplicitlyDenied", "blockedBy": ["rcp"] }
+    "expected": {
+      "response": "ExplicitlyDenied",
+      "blockedBy": ["rcp"]
+    }
   },
   {
     "name": "anonymous ignores SCP explicit deny",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -139,14 +178,21 @@
         }
       ]
     },
-    "expected": { "response": "Allowed" }
+    "expected": {
+      "response": "Allowed"
+    }
   },
   {
     "name": "anonymous denied when resource policy allows only specific principal",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -157,20 +203,29 @@
       "Statement": [
         {
           "Effect": "Allow",
-          "Principal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/Alice"
+          },
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*"
         }
       ]
     },
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   },
   {
     "name": "anonymous denied when resource policy allows only account principal",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -181,20 +236,29 @@
       "Statement": [
         {
           "Effect": "Allow",
-          "Principal": { "AWS": "arn:aws:iam::123456789012:root" },
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:root"
+          },
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*"
         }
       ]
     },
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   },
   {
     "name": "anonymous denied when resource policy allows only service principal",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -205,20 +269,29 @@
       "Statement": [
         {
           "Effect": "Allow",
-          "Principal": { "Service": "ec2.amazonaws.com" },
+          "Principal": {
+            "Service": "ec2.amazonaws.com"
+          },
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*"
         }
       ]
     },
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   },
   {
     "name": "anonymous allowed by not principal excluding signed principal",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -229,20 +302,29 @@
       "Statement": [
         {
           "Effect": "Allow",
-          "NotPrincipal": { "AWS": "arn:aws:iam::123456789012:user/Alice" },
+          "NotPrincipal": {
+            "AWS": "arn:aws:iam::123456789012:user/Alice"
+          },
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*"
         }
       ]
     },
-    "expected": { "response": "Allowed" }
+    "expected": {
+      "response": "Allowed"
+    }
   },
   {
     "name": "anonymous denied by wildcard not principal",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -259,15 +341,24 @@
         }
       ]
     },
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   },
   {
     "name": "anonymous condition key must match when present in resource policy",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
-      "context": { "aws:SecureTransport": "true" }
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
+      "context": {
+        "aws:SecureTransport": "true"
+      }
     },
     "identityPolicies": [],
     "serviceControlPolicies": [],
@@ -280,18 +371,29 @@
           "Principal": "*",
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*",
-          "Condition": { "Bool": { "aws:SecureTransport": "true" } }
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "true"
+            }
+          }
         }
       ]
     },
-    "expected": { "response": "Allowed" }
+    "expected": {
+      "response": "Allowed"
+    }
   },
   {
     "name": "anonymous condition key missing prevents resource policy allow",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -305,18 +407,29 @@
           "Principal": "*",
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*",
-          "Condition": { "Bool": { "aws:SecureTransport": "true" } }
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "true"
+            }
+          }
         }
       ]
     },
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   },
   {
     "name": "anonymous discovery mode only ignores conditions from supplied constraints",
     "request": {
       "action": "s3:GetObject",
-      "resource": { "resource": "arn:aws:s3:::public-bucket/key.txt", "accountId": "123456789012" },
-      "principal": { "type": "Anonymous" },
+      "resource": {
+        "resource": "arn:aws:s3:::public-bucket/key.txt",
+        "accountId": "123456789012"
+      },
+      "principal": {
+        "type": "Anonymous"
+      },
       "context": {}
     },
     "identityPolicies": [],
@@ -330,22 +443,50 @@
           "Principal": "*",
           "Action": "s3:GetObject",
           "Resource": "arn:aws:s3:::public-bucket/*",
-          "Condition": { "Bool": { "aws:SecureTransport": "true" } }
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "true"
+            }
+          }
         }
       ]
     },
     "simulation": {
       "mode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SecureTransport", "presenceIsKnown": false, "valueIsKnown": false }
+        {
+          "keyName": "aws:SecureTransport",
+          "presenceIsKnown": false,
+          "valueIsKnown": false
+        }
       ]
     },
     "expected": {
       "response": "Allowed",
       "ignoredConditions": {
         "resource": {
-          "allow": [{ "op": "Bool", "key": "aws:SecureTransport", "values": ["true"] }]
+          "allow": [
+            {
+              "op": "Bool",
+              "key": "aws:SecureTransport",
+              "values": ["true"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "Bool",
+        "key": "aws:SecureTransport",
+        "values": ["true"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   }

--- a/src/core_engine/coreEngineTests/discoveryMode/allowedConditions/matrix.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/allowedConditions/matrix.json
@@ -1,0 +1,2588 @@
+[
+  {
+    "name": "Same-account conditions are identity allow OR direct resource allow",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "IpAddress": {
+                "aws:SourceIp": "203.0.113.0/24"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::matrix-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-resource"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceIp",
+              "op": "IpAddress",
+              "values": ["203.0.113.0/24"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-resource"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "or",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-resource"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "IpAddress",
+            "key": "aws:SourceIp",
+            "values": ["203.0.113.0/24"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "KMS same-account account trust conditions are ANDed with identity conditions",
+    "request": {
+      "action": "kms:DescribeKey",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:key/1234",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:DescribeKey",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:key/1234",
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestTag/Env": "prod"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "kms:DescribeKey",
+          "Resource": "*",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:root"
+          },
+          "Condition": {
+            "StringEquals": {
+              "kms:ViaService": "ec2.us-east-1.amazonaws.com"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "kms:ViaService",
+            "values": ["ec2.us-east-1.amazonaws.com"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:RequestTag/Env",
+            "values": ["prod"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      },
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:RequestTag/Env",
+              "op": "StringEquals",
+              "values": ["prod"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "kms:ViaService",
+              "op": "StringEquals",
+              "values": ["ec2.us-east-1.amazonaws.com"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "SCP conditions combine OU allows with escaped deny",
+    "request": {
+      "action": "s3:ListAllMyBuckets",
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:RequestedRegion": "us-west-2"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListAllMyBuckets",
+            "Resource": "*"
+          }
+        ]
+      }
+    ],
+    "serviceControlPolicies": [
+      {
+        "orgIdentifier": "ou-a",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:PrincipalOrgID": "o-a"
+                  }
+                }
+              },
+              {
+                "Effect": "Deny",
+                "Action": "s3:ListAllMyBuckets",
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "us-west-2"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "orgIdentifier": "ou-b",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "*",
+                "Resource": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:ResourceOrgID": "o-b"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:PrincipalOrgID",
+            "values": ["o-a"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "scp",
+                "statementIndex": 1,
+                "orgIdentifier": "ou-a"
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:ResourceOrgID",
+            "values": ["o-b"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "scp",
+                "statementIndex": 1,
+                "orgIdentifier": "ou-b"
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:RequestedRegion",
+            "values": ["us-west-2"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "scp",
+                "statementIndex": 2,
+                "orgIdentifier": "ou-a"
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      },
+      "ignoredConditions": {
+        "scp": {
+          "allow": [
+            {
+              "key": "aws:PrincipalOrgID",
+              "op": "StringEquals",
+              "values": ["o-a"]
+            },
+            {
+              "key": "aws:ResourceOrgID",
+              "op": "StringEquals",
+              "values": ["o-b"]
+            }
+          ],
+          "deny": [
+            {
+              "key": "aws:RequestedRegion",
+              "op": "StringEquals",
+              "values": ["us-west-2"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "RCP deny escapes from multiple org levels are ANDed",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:RequestedRegion": "us-east-1",
+        "aws:SourceVpc": "vpc-deny"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket"
+          }
+        ]
+      }
+    ],
+    "resourceControlPolicies": [
+      {
+        "orgIdentifier": "ou-a",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Deny",
+                "Action": "s3:ListBucket",
+                "Resource": "*",
+                "Principal": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:RequestedRegion": "us-east-1"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "orgIdentifier": "ou-b",
+        "policies": [
+          {
+            "Version": "2012-10-17",
+            "Statement": [
+              {
+                "Effect": "Deny",
+                "Action": "s3:ListBucket",
+                "Resource": "*",
+                "Principal": "*",
+                "Condition": {
+                  "StringEquals": {
+                    "aws:SourceVpc": "vpc-deny"
+                  }
+                }
+              }
+            ]
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "rcp": {
+          "deny": [
+            {
+              "key": "aws:RequestedRegion",
+              "op": "StringEquals",
+              "values": ["us-east-1"]
+            },
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-deny"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:RequestedRegion",
+            "values": ["us-east-1"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "rcp",
+                "statementIndex": 1,
+                "orgIdentifier": "ou-a"
+              }
+            ],
+            "inverted": true
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-deny"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "1",
+                "policyType": "rcp",
+                "statementIndex": 1,
+                "orgIdentifier": "ou-b"
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Multiple conditions in one allow statement are ANDed",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket/key",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::matrix-bucket/key",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "true"
+            },
+            "NumericGreaterThanEquals": {
+              "s3:TlsVersion": "1.2"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "Bool",
+            "key": "aws:SecureTransport",
+            "values": ["true"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "NumericGreaterThanEquals",
+            "key": "s3:TlsVersion",
+            "values": ["1.2"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      },
+      "ignoredConditions": {
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SecureTransport",
+              "op": "Bool",
+              "values": ["true"]
+            },
+            {
+              "key": "s3:TlsVersion",
+              "op": "NumericGreaterThanEquals",
+              "values": ["1.2"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "Known matching condition in allow statement is not returned in conditions",
+    "request": {
+      "action": "s3:GetObject",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket/key",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:SecureTransport": "true"
+      }
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:GetObject",
+          "Resource": "arn:aws:s3:::matrix-bucket/key",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "Bool": {
+              "aws:SecureTransport": "true"
+            },
+            "NumericGreaterThanEquals": {
+              "s3:TlsVersion": "1.2"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "resource": {
+          "allow": [
+            {
+              "key": "s3:TlsVersion",
+              "op": "NumericGreaterThanEquals",
+              "values": ["1.2"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "NumericGreaterThanEquals",
+        "key": "s3:TlsVersion",
+        "values": ["1.2"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Permission boundary allow conditions do not constrain unconditional same-account direct resource path",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-identity"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::matrix-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          }
+        }
+      ]
+    },
+    "permissionBoundaries": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpce": "vpce-boundary"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-identity"]
+            }
+          ]
+        },
+        "permissionBoundary": {
+          "allow": [
+            {
+              "key": "aws:SourceVpce",
+              "op": "StringEquals",
+              "values": ["vpce-boundary"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "Permission boundary implicit deny recalculates conditions from bypassing resource statements only",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-identity"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::matrix-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-resource"
+            }
+          }
+        }
+      ]
+    },
+    "permissionBoundaries": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "ec2:*",
+            "Resource": "*"
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-resource"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      },
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-identity"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-resource"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "IfExists deny inversion is represented in end-to-end conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEqualsIfExists": {
+                "aws:SourceVpc": "vpc-deny"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "Null",
+            "key": "aws:SourceVpc",
+            "values": ["false"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-deny"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      },
+      "ignoredConditions": {
+        "identity": {
+          "deny": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEqualsIfExists",
+              "values": ["vpc-deny"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "Separate conditional resource allow statements are ORed",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::matrix-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-one"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::matrix-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "IpAddress": {
+              "aws:SourceIp": "198.51.100.0/24"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-one"]
+            },
+            {
+              "key": "aws:SourceIp",
+              "op": "IpAddress",
+              "values": ["198.51.100.0/24"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "or",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-one"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "IpAddress",
+            "key": "aws:SourceIp",
+            "values": ["198.51.100.0/24"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 2
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Unconditional explicit deny omits conditions because final result is denied",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-allow"
+              }
+            }
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket"
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "ExplicitlyDenied",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-allow"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "STS same-account trust policy conditions are ANDed with identity conditions",
+    "request": {
+      "action": "sts:AssumeRole",
+      "resource": {
+        "resource": "arn:aws:iam::123456789012:role/test-role",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::123456789012:role/test-role",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceIdentity": "source-id"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Resource": "*",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:root"
+          },
+          "Condition": {
+            "StringEquals": {
+              "sts:ExternalId": "external-id"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceIdentity",
+              "op": "StringEquals",
+              "values": ["source-id"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "sts:ExternalId",
+              "op": "StringEquals",
+              "values": ["external-id"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "sts:ExternalId",
+            "values": ["external-id"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceIdentity",
+            "values": ["source-id"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "IAM service-specific implicit deny omits conditions after conditional core allow",
+    "request": {
+      "action": "iam:DeletePolicy",
+      "resource": {
+        "resource": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+        "accountId": "aws"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "iam:DeletePolicy",
+            "Resource": "arn:aws:iam::aws:policy/ReadOnlyAccess",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-iam"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "ImplicitlyDenied",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-iam"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "Cross-account direct resource conditions are ANDed with identity conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::cross-bucket",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::cross-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-identity"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::cross-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:user/test-user"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:PrincipalOrgID": "o-direct"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-identity"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:PrincipalOrgID",
+              "op": "StringEquals",
+              "values": ["o-direct"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:PrincipalOrgID",
+            "values": ["o-direct"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-identity"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Cross-account account-level resource conditions are ANDed with identity conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::cross-bucket",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::cross-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-identity"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::cross-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:PrincipalOrgID": "o-account"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-identity"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:PrincipalOrgID",
+              "op": "StringEquals",
+              "values": ["o-account"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:PrincipalOrgID",
+            "values": ["o-account"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-identity"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Deny with multiple condition keys becomes OR of inverted leaves in final conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:RequestedRegion": "us-east-1",
+        "aws:SourceIp": "10.1.2.3"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-allow"
+              }
+            }
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestedRegion": "us-east-1"
+              },
+              "IpAddress": {
+                "aws:SourceIp": "10.0.0.0/8"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-allow"]
+            }
+          ],
+          "deny": [
+            {
+              "key": "aws:RequestedRegion",
+              "op": "StringEquals",
+              "values": ["us-east-1"]
+            },
+            {
+              "key": "aws:SourceIp",
+              "op": "IpAddress",
+              "values": ["10.0.0.0/8"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-allow"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "group",
+            "operator": "or",
+            "conditions": [
+              {
+                "conditionType": "condition",
+                "op": "StringNotEquals",
+                "key": "aws:RequestedRegion",
+                "values": ["us-east-1"],
+                "sources": [
+                  {
+                    "effect": "Deny",
+                    "policyIdentifier": "0",
+                    "policyType": "identity",
+                    "statementIndex": 2
+                  }
+                ],
+                "inverted": true
+              },
+              {
+                "conditionType": "condition",
+                "op": "NotIpAddress",
+                "key": "aws:SourceIp",
+                "values": ["10.0.0.0/8"],
+                "sources": [
+                  {
+                    "effect": "Deny",
+                    "policyIdentifier": "0",
+                    "policyType": "identity",
+                    "statementIndex": 2
+                  }
+                ],
+                "inverted": true
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Permission boundary allow conditions are ANDed with identity allow conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-identity"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "permissionBoundaries": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpce": "vpce-boundary"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-identity"]
+            }
+          ]
+        },
+        "permissionBoundary": {
+          "allow": [
+            {
+              "key": "aws:SourceVpce",
+              "op": "StringEquals",
+              "values": ["vpce-boundary"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-identity"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpce",
+            "values": ["vpce-boundary"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "permissionBoundary",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Permission boundary allow preserves direct resource path OR identity boundary path",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-identity"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::matrix-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-resource"
+            }
+          }
+        }
+      ]
+    },
+    "permissionBoundaries": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpce": "vpce-boundary"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-identity"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-resource"]
+            }
+          ]
+        },
+        "permissionBoundary": {
+          "allow": [
+            {
+              "key": "aws:SourceVpce",
+              "op": "StringEquals",
+              "values": ["vpce-boundary"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "or",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-resource"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "group",
+            "operator": "and",
+            "conditions": [
+              {
+                "conditionType": "condition",
+                "op": "StringEquals",
+                "key": "aws:SourceVpc",
+                "values": ["vpc-identity"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "0",
+                    "policyType": "identity",
+                    "statementIndex": 1
+                  }
+                ]
+              },
+              {
+                "conditionType": "condition",
+                "op": "StringEquals",
+                "key": "aws:SourceVpce",
+                "values": ["vpce-boundary"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "0",
+                    "policyType": "permissionBoundary",
+                    "statementIndex": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Explicit account trust permission boundary allow preserves direct resource path OR trusted identity boundary path",
+    "request": {
+      "action": "sts:AssumeRole",
+      "resource": {
+        "resource": "arn:aws:iam::123456789012:role/test-role",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "arn:aws:iam::123456789012:role/test-role",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceIdentity": "source-id"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Resource": "*",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:user/test-user"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-resource"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "sts:AssumeRole",
+          "Resource": "*",
+          "Principal": {
+            "AWS": "arn:aws:iam::123456789012:root"
+          },
+          "Condition": {
+            "StringEquals": {
+              "sts:ExternalId": "external-id"
+            }
+          }
+        }
+      ]
+    },
+    "permissionBoundaries": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "sts:AssumeRole",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpce": "vpce-boundary"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceIdentity",
+              "op": "StringEquals",
+              "values": ["source-id"]
+            }
+          ]
+        },
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-resource"]
+            },
+            {
+              "key": "sts:ExternalId",
+              "op": "StringEquals",
+              "values": ["external-id"]
+            }
+          ]
+        },
+        "permissionBoundary": {
+          "allow": [
+            {
+              "key": "aws:SourceVpce",
+              "op": "StringEquals",
+              "values": ["vpce-boundary"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "or",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-resource"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "group",
+            "operator": "and",
+            "conditions": [
+              {
+                "conditionType": "condition",
+                "op": "StringEquals",
+                "key": "sts:ExternalId",
+                "values": ["external-id"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "ResourcePolicy",
+                    "policyType": "resource",
+                    "statementIndex": 2
+                  }
+                ]
+              },
+              {
+                "conditionType": "condition",
+                "op": "StringEquals",
+                "key": "aws:SourceIdentity",
+                "values": ["source-id"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "0",
+                    "policyType": "identity",
+                    "statementIndex": 1
+                  }
+                ]
+              },
+              {
+                "conditionType": "condition",
+                "op": "StringEquals",
+                "key": "aws:SourceVpce",
+                "values": ["vpce-boundary"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "0",
+                    "policyType": "permissionBoundary",
+                    "statementIndex": 1
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "STS GetCallerIdentity discovery short-circuit omits conditions",
+    "request": {
+      "action": "sts:GetCallerIdentity",
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "sts:GetCallerIdentity",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-sts"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-sts"]
+            }
+          ]
+        }
+      }
+    }
+  },
+  {
+    "name": "ForAllValues deny inversion is represented in end-to-end conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "ForAllValues:StringEquals": {
+                "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "deny": [
+            {
+              "key": "aws:SourceOrgPaths",
+              "op": "ForAllValues:StringEquals",
+              "values": ["o-abc/r-root/ou-team/app"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "Null",
+            "key": "aws:SourceOrgPaths",
+            "values": ["false"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          },
+          {
+            "conditionType": "condition",
+            "op": "ForAnyValue:StringNotEquals",
+            "key": "aws:SourceOrgPaths",
+            "values": ["o-abc/r-root/ou-team/app"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "ForAllValues IfExists deny inversion is represented in end-to-end conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "ForAllValues:StringEqualsIfExists": {
+                "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "deny": [
+            {
+              "key": "aws:SourceOrgPaths",
+              "op": "ForAllValues:StringEqualsIfExists",
+              "values": ["o-abc/r-root/ou-team/app"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "Null",
+            "key": "aws:SourceOrgPaths",
+            "values": ["false"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          },
+          {
+            "conditionType": "condition",
+            "op": "ForAnyValue:StringNotEquals",
+            "key": "aws:SourceOrgPaths",
+            "values": ["o-abc/r-root/ou-team/app"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "ForAnyValue deny inversion is represented in end-to-end conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "ForAnyValue:StringEquals": {
+                "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "deny": [
+            {
+              "key": "aws:SourceOrgPaths",
+              "op": "ForAnyValue:StringEquals",
+              "values": ["o-abc/r-root/ou-team/app"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "or",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "Null",
+            "key": "aws:SourceOrgPaths",
+            "values": ["true"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          },
+          {
+            "conditionType": "condition",
+            "op": "ForAllValues:StringNotEquals",
+            "key": "aws:SourceOrgPaths",
+            "values": ["o-abc/r-root/ou-team/app"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Multiple identity allows are ORed before deny escapes are ANDed",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:RequestedRegion": "us-east-1"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-one"
+              }
+            }
+          },
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "IpAddress": {
+                "aws:SourceIp": "203.0.113.0/24"
+              }
+            }
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:RequestedRegion": "us-east-1"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-one"]
+            },
+            {
+              "key": "aws:SourceIp",
+              "op": "IpAddress",
+              "values": ["203.0.113.0/24"]
+            }
+          ],
+          "deny": [
+            {
+              "key": "aws:RequestedRegion",
+              "op": "StringEquals",
+              "values": ["us-east-1"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "group",
+            "operator": "or",
+            "conditions": [
+              {
+                "conditionType": "condition",
+                "op": "StringEquals",
+                "key": "aws:SourceVpc",
+                "values": ["vpc-one"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "0",
+                    "policyType": "identity",
+                    "statementIndex": 1
+                  }
+                ]
+              },
+              {
+                "conditionType": "condition",
+                "op": "IpAddress",
+                "key": "aws:SourceIp",
+                "values": ["203.0.113.0/24"],
+                "sources": [
+                  {
+                    "effect": "Allow",
+                    "policyIdentifier": "0",
+                    "policyType": "identity",
+                    "statementIndex": 2
+                  }
+                ]
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:RequestedRegion",
+            "values": ["us-east-1"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 3
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Permission boundary explicit deny escape is ANDed with identity allow conditions",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::matrix-bucket",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {
+        "aws:SourceVpc": "vpc-denied"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::matrix-bucket",
+            "Condition": {
+              "StringEquals": {
+                "aws:PrincipalTag/team": "blue"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "permissionBoundaries": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceVpc": "vpc-denied"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:PrincipalTag/team",
+              "op": "StringEquals",
+              "values": ["blue"]
+            }
+          ]
+        },
+        "permissionBoundary": {
+          "deny": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-denied"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:PrincipalTag/team",
+            "values": ["blue"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "0",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-denied"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "0",
+                "policyType": "permissionBoundary",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          }
+        ]
+      }
+    }
+  }
+]

--- a/src/core_engine/coreEngineTests/discoveryMode/contextKeyConstraints/sourceContext.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/contextKeyConstraints/sourceContext.json
@@ -3,9 +3,14 @@
     "name": "Allow condition with known presence and unknown value is ignored",
     "request": {
       "action": "s3:ListBucket",
-      "resource": { "resource": "*", "accountId": "123456789012" },
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
       "principal": "arn:aws:iam::123456789012:user/Alice",
-      "context": { "aws:SourceAccount": "000000000000" }
+      "context": {
+        "aws:SourceAccount": "000000000000"
+      }
     },
     "identityPolicies": [
       {
@@ -15,7 +20,11 @@
             "Effect": "Allow",
             "Action": "s3:ListBucket",
             "Resource": "*",
-            "Condition": { "StringEquals": { "aws:SourceAccount": "111111111111" } }
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
           }
         ]
       }
@@ -23,7 +32,11 @@
     "simulation": {
       "mode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SourceAccount", "presenceIsKnown": true, "valueIsKnown": false }
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
       ]
     },
     "expected": {
@@ -31,9 +44,27 @@
       "ignoredConditions": {
         "identity": {
           "allow": [
-            { "key": "aws:SourceAccount", "op": "StringEquals", "values": ["111111111111"] }
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringEquals",
+              "values": ["111111111111"]
+            }
           ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   },
@@ -41,20 +72,33 @@
     "name": "Deny condition with known presence and unknown value is ignored",
     "request": {
       "action": "s3:ListBucket",
-      "resource": { "resource": "*", "accountId": "123456789012" },
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
       "principal": "arn:aws:iam::123456789012:user/Alice",
-      "context": { "aws:SourceAccount": "000000000000" }
+      "context": {
+        "aws:SourceAccount": "000000000000"
+      }
     },
     "identityPolicies": [
       {
         "Version": "2012-10-17",
         "Statement": [
-          { "Effect": "Allow", "Action": "s3:ListBucket", "Resource": "*" },
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*"
+          },
           {
             "Effect": "Deny",
             "Action": "s3:ListBucket",
             "Resource": "*",
-            "Condition": { "StringEquals": { "aws:SourceAccount": "111111111111" } }
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
           }
         ]
       }
@@ -62,15 +106,40 @@
     "simulation": {
       "mode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SourceAccount", "presenceIsKnown": true, "valueIsKnown": false }
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
       ]
     },
     "expected": {
       "response": "Allowed",
       "ignoredConditions": {
         "identity": {
-          "deny": [{ "key": "aws:SourceAccount", "op": "StringEquals", "values": ["111111111111"] }]
+          "deny": [
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringEquals",
+              "values": ["111111111111"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEquals",
+        "key": "aws:SourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 2
+          }
+        ],
+        "inverted": true
       }
     }
   },
@@ -78,9 +147,14 @@
     "name": "Null false matches when presence is known and value is unknown",
     "request": {
       "action": "s3:ListBucket",
-      "resource": { "resource": "*", "accountId": "123456789012" },
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
       "principal": "arn:aws:iam::123456789012:user/Alice",
-      "context": { "aws:SourceAccount": "000000000000" }
+      "context": {
+        "aws:SourceAccount": "000000000000"
+      }
     },
     "identityPolicies": [
       {
@@ -90,7 +164,11 @@
             "Effect": "Allow",
             "Action": "s3:ListBucket",
             "Resource": "*",
-            "Condition": { "Null": { "aws:SourceAccount": "false" } }
+            "Condition": {
+              "Null": {
+                "aws:SourceAccount": "false"
+              }
+            }
           }
         ]
       }
@@ -98,18 +176,29 @@
     "simulation": {
       "mode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SourceAccount", "presenceIsKnown": true, "valueIsKnown": false }
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
       ]
     },
-    "expected": { "response": "Allowed" }
+    "expected": {
+      "response": "Allowed"
+    }
   },
   {
     "name": "Null true does not match when presence is known and key is present",
     "request": {
       "action": "s3:ListBucket",
-      "resource": { "resource": "*", "accountId": "123456789012" },
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
       "principal": "arn:aws:iam::123456789012:user/Alice",
-      "context": { "aws:SourceAccount": "000000000000" }
+      "context": {
+        "aws:SourceAccount": "000000000000"
+      }
     },
     "identityPolicies": [
       {
@@ -119,7 +208,11 @@
             "Effect": "Allow",
             "Action": "s3:ListBucket",
             "Resource": "*",
-            "Condition": { "Null": { "aws:SourceAccount": "true" } }
+            "Condition": {
+              "Null": {
+                "aws:SourceAccount": "true"
+              }
+            }
           }
         ]
       }
@@ -127,9 +220,15 @@
     "simulation": {
       "mode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SourceAccount", "presenceIsKnown": true, "valueIsKnown": false }
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
       ]
     },
-    "expected": { "response": "ImplicitlyDenied" }
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
   }
 ]

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/identityAllow.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/identityAllow.json
@@ -36,12 +36,31 @@
       "response": "Allowed",
       "ignoredConditions": {
         "identity": {
-          "allow": [{ "key": "aws:SourceVpc", "op": "StringEquals", "values": ["vpc-123456"] }]
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-123456"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-123456"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   },
-
   {
     "name": "Does not report ignored conditions when the statement does not apply",
     "request": {

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/permissionBoundary.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/permissionBoundary.json
@@ -48,8 +48,28 @@
       "response": "Allowed",
       "ignoredConditions": {
         "permissionBoundary": {
-          "allow": [{ "key": "aws:SourceVpc", "op": "StringEquals", "values": ["vpc-123456"] }]
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-123456"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-123456"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "permissionBoundary",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   },
@@ -107,8 +127,29 @@
       "response": "Allowed",
       "ignoredConditions": {
         "permissionBoundary": {
-          "deny": [{ "key": "aws:SourceVpc", "op": "StringNotEquals", "values": ["vpc-123456"] }]
+          "deny": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringNotEquals",
+              "values": ["vpc-123456"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-123456"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "0",
+            "policyType": "permissionBoundary",
+            "statementIndex": 2
+          }
+        ],
+        "inverted": true
       }
     }
   },

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/rcp.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/rcp.json
@@ -73,6 +73,22 @@
             }
           ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEquals",
+        "key": "aws:Username",
+        "values": ["test-user"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "0",
+            "policyType": "rcp",
+            "statementIndex": 1,
+            "orgIdentifier": "ou-1"
+          }
+        ],
+        "inverted": true
       }
     }
   },

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/resources.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/resources.json
@@ -36,8 +36,28 @@
       "response": "Allowed",
       "ignoredConditions": {
         "resource": {
-          "allow": [{ "key": "aws:SourceVpc", "op": "StringEquals", "values": ["vpc-123456"] }]
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-123456"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-123456"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   },
@@ -87,8 +107,29 @@
       "response": "Allowed",
       "ignoredConditions": {
         "resource": {
-          "deny": [{ "key": "aws:SourceVpc", "op": "StringNotEquals", "values": ["vpc-123456"] }]
+          "deny": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringNotEquals",
+              "values": ["vpc-123456"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-123456"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ],
+        "inverted": true
       }
     }
   },
@@ -136,6 +177,117 @@
     },
     "expected": {
       "response": "Allowed"
+    }
+  },
+  {
+    "name": "Cross-account resource conditions include direct and account-level allow paths",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "arn:aws:s3:::mybucket",
+        "accountId": "222222222222"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "arn:aws:s3:::mybucket"
+          }
+        ]
+      }
+    ],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::mybucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/test-role"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-direct"
+            }
+          }
+        },
+        {
+          "Effect": "Allow",
+          "Action": "s3:ListBucket",
+          "Resource": "arn:aws:s3:::mybucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:root"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceVpc": "vpc-account"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-direct"]
+            },
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-account"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "or",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-direct"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceVpc",
+            "values": ["vpc-account"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 2
+              }
+            ]
+          }
+        ]
+      }
     }
   }
 ]

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/scp.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/scp.json
@@ -71,6 +71,22 @@
             }
           ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEquals",
+        "key": "aws:Username",
+        "values": ["test-user"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "1",
+            "policyType": "scp",
+            "statementIndex": 1,
+            "orgIdentifier": "ou-1"
+          }
+        ],
+        "inverted": true
       }
     }
   },

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/strictPatterns.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/strictPatterns.json
@@ -95,6 +95,20 @@
             }
           ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:PrincipalTag/Team",
+        "values": ["Accounting"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   }

--- a/src/core_engine/coreEngineTests/discoveryMode/roleVsSession.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/roleVsSession.json
@@ -29,7 +29,19 @@
     },
     "expected": {
       "response": "Allowed",
-      "ignoredRoleSessionName": true
+      "ignoredRoleSessionName": true,
+      "conditions": {
+        "conditionType": "sessionName",
+        "sessionName": ["session-name"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
     }
   },
   {
@@ -62,7 +74,19 @@
     },
     "expected": {
       "response": "Allowed",
-      "ignoredRoleSessionName": true
+      "ignoredRoleSessionName": true,
+      "conditions": {
+        "conditionType": "sessionName",
+        "sessionName": ["session-name"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
     }
   },
   {
@@ -95,7 +119,19 @@
     },
     "expected": {
       "response": "Allowed",
-      "ignoredRoleSessionName": true
+      "ignoredRoleSessionName": true,
+      "conditions": {
+        "conditionType": "sessionName",
+        "sessionName": ["session-name"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
     }
   },
   {
@@ -128,7 +164,19 @@
     },
     "expected": {
       "response": "Allowed",
-      "ignoredRoleSessionName": true
+      "ignoredRoleSessionName": true,
+      "conditions": {
+        "conditionType": "sessionName",
+        "sessionName": ["session-name"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
     }
   },
   {
@@ -173,7 +221,19 @@
     },
     "expected": {
       "response": "Allowed",
-      "ignoredRoleSessionName": true
+      "ignoredRoleSessionName": true,
+      "conditions": {
+        "conditionType": "sessionName",
+        "sessionName": ["session-name"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
     }
   },
   {
@@ -218,7 +278,19 @@
     },
     "expected": {
       "response": "Allowed",
-      "ignoredRoleSessionName": true
+      "ignoredRoleSessionName": true,
+      "conditions": {
+        "conditionType": "sessionName",
+        "sessionName": ["session-name"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
     }
   },
   {

--- a/src/core_engine/coreEngineTests/endpoints/conditionDiscovery.json
+++ b/src/core_engine/coreEngineTests/endpoints/conditionDiscovery.json
@@ -45,8 +45,28 @@
       "response": "Allowed",
       "ignoredConditions": {
         "endpointPolicy": {
-          "allow": [{ "op": "StringEquals", "key": "aws:SourceVpce", "values": ["vpce-12345678"] }]
+          "allow": [
+            {
+              "op": "StringEquals",
+              "key": "aws:SourceVpce",
+              "values": ["vpce-12345678"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpce",
+        "values": ["vpce-12345678"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "endpointPolicy",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   }

--- a/src/core_engine/coreEngineTests/sessionPolicies.json
+++ b/src/core_engine/coreEngineTests/sessionPolicies.json
@@ -324,8 +324,28 @@
       "response": "Allowed",
       "ignoredConditions": {
         "session": {
-          "allow": [{ "key": "aws:SourceVpc", "op": "StringEquals", "values": ["vpc-123456"] }]
+          "allow": [
+            {
+              "key": "aws:SourceVpc",
+              "op": "StringEquals",
+              "values": ["vpc-123456"]
+            }
+          ]
         }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceVpc",
+        "values": ["vpc-123456"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "SessionPolicy",
+            "policyType": "session",
+            "statementIndex": 1
+          }
+        ]
       }
     }
   }

--- a/src/core_engine/coreSimulatorEngine.test.ts
+++ b/src/core_engine/coreSimulatorEngine.test.ts
@@ -161,6 +161,12 @@ describe('coreSimulatorEngine', () => {
             expect(analysis.ignoredRoleSessionName).toBeFalsy()
           }
 
+          if (expected.conditions) {
+            expect(analysis.conditions).toEqual(expected.conditions)
+          } else {
+            expect(analysis.conditions, 'unexpected conditions').toBeUndefined()
+          }
+
           if (expected.ignoredConditions) {
             for (const key of conditionKeysToVerify) {
               const actualAllow = (analysis.ignoredConditions as any)?.[key]?.allow

--- a/src/evaluate.ts
+++ b/src/evaluate.ts
@@ -31,6 +31,7 @@ export interface OuScpAnalysis {
   denyStatements: StatementAnalysis[]
   allowStatements: StatementAnalysis[]
   unmatchedStatements: StatementAnalysis[]
+  conditions: AllowedConditionExpression
 }
 
 export interface ScpAnalysis {
@@ -39,6 +40,7 @@ export interface ScpAnalysis {
    */
   result: EvaluationResult
   ouAnalysis: OuScpAnalysis[]
+  conditions: AllowedConditionExpression
 }
 
 export interface OuRcpAnalysis {
@@ -47,6 +49,7 @@ export interface OuRcpAnalysis {
   denyStatements: StatementAnalysis[]
   allowStatements: StatementAnalysis[]
   unmatchedStatements: StatementAnalysis[]
+  conditions: AllowedConditionExpression
 }
 
 export interface RcpAnalysis {
@@ -55,6 +58,7 @@ export interface RcpAnalysis {
    */
   result: EvaluationResult
   ouAnalysis: OuRcpAnalysis[]
+  conditions: AllowedConditionExpression
 }
 
 export interface IgnoredCondition {
@@ -66,6 +70,59 @@ export interface IgnoredCondition {
 /**
  * Conditions that were ignored during discovery mode.
  */
+export type AllowedConditionExpression =
+  | AlwaysAllowedCondition
+  | NeverAllowedCondition
+  | AllowedConditionGroup
+  | AllowedConditionLeaf
+  | AllowedSessionNameCondition
+
+/** A condition expression that is always satisfied. */
+export interface AlwaysAllowedCondition {
+  conditionType: 'always'
+}
+
+/** A condition expression that cannot be satisfied. */
+export interface NeverAllowedCondition {
+  conditionType: 'never'
+  reason: 'explicitDenyWithoutConditions' | 'noApplicableAllow'
+}
+
+/** A boolean grouping of allowed-condition expressions. */
+export interface AllowedConditionGroup {
+  conditionType: 'group'
+  operator: 'and' | 'or'
+  conditions: AllowedConditionExpression[]
+}
+
+/** A policy condition that must hold for access to be allowed. */
+export interface AllowedConditionLeaf {
+  conditionType: 'condition'
+  op: string
+  key: string
+  values: string[]
+  sources: AllowedConditionSource[]
+  inverted?: true
+}
+
+/** A role session-name constraint that must hold for access to be allowed. */
+export interface AllowedSessionNameCondition {
+  conditionType: 'sessionName'
+  sessionName: string[]
+  sources: AllowedConditionSource[]
+}
+
+/** Metadata for the statement that contributed an allowed condition. */
+export interface AllowedConditionSource {
+  policyType:
+    'session' | 'identity' | 'resource' | 'scp' | 'rcp' | 'permissionBoundary' | 'endpointPolicy'
+  effect: 'Allow' | 'Deny'
+  policyIdentifier?: string
+  orgIdentifier?: string
+  statementId?: string
+  statementIndex: number
+}
+
 export interface IgnoredConditions {
   session?: {
     allow?: IgnoredCondition[]
@@ -145,6 +202,14 @@ export interface RequestAnalysis {
    * The result of the evaluation of the VPC endpoint policies, if any.
    */
   endpointAnalysis?: IdentityAnalysis | undefined
+
+  /**
+   * The conditions under which a Discovery-mode request is allowed.
+   *
+   * This is only present for final Allowed results when access depends on conditions
+   * ignored because their request-context presence or value was unknown.
+   */
+  conditions?: AllowedConditionExpression
 
   /**
    * Any conditions that were ignored during discovery mode.

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,10 +15,17 @@ export type { DiscoveryContextKeyConstraint } from './context_keys/discoveryCont
 export { findContextKeys } from './context_keys/findContextKeys.js'
 export type { SimulationMode } from './core_engine/CoreSimulatorEngine.js'
 export type {
+  AllowedConditionExpression,
+  AllowedConditionGroup,
+  AllowedConditionLeaf,
+  AllowedConditionSource,
+  AllowedSessionNameCondition,
+  AlwaysAllowedCondition,
   BlockedReason,
   EvaluationResult,
   IgnoredCondition,
   IgnoredConditions,
+  NeverAllowedCondition,
   RequestAnalysis
 } from './evaluate.js'
 export type {

--- a/src/services/DefaultServiceAuthorizer.ts
+++ b/src/services/DefaultServiceAuthorizer.ts
@@ -1,4 +1,15 @@
 import {
+  allDenyEscapeExpressions,
+  allowedConditionOutput,
+  and,
+  endpointPolicyExpression,
+  identityPolicyExpression,
+  or,
+  permissionBoundaryExpression,
+  resourceAllowStatementsExpression,
+  sessionPolicyExpression
+} from '../analysis/allowedConditions.js'
+import {
   isAssumedRoleArn,
   isFederatedUserArn,
   isIamRoleArn,
@@ -6,6 +17,7 @@ import {
   isServicePrincipal
 } from '@cloud-copilot/iam-utils'
 import {
+  type AllowedConditionExpression,
   type BlockedReason,
   type EvaluationResult,
   type RequestAnalysis,
@@ -13,6 +25,7 @@ import {
 } from '../evaluate.js'
 import { assertAuthenticatedRequestPrincipal } from '../request/requestPrincipal.js'
 import { type RequestResource } from '../request/requestResource.js'
+import { type StatementAnalysis } from '../StatementAnalysis.js'
 import { type ServiceAuthorizationRequest, type ServiceAuthorizer } from './ServiceAuthorizer.js'
 
 /**
@@ -84,6 +97,21 @@ class BlockedByLog {
   }
 }
 
+interface InitialEvaluation {
+  result: EvaluationResult
+  conditions: AllowedConditionExpression
+}
+
+interface PermissionBoundaryMutation {
+  result?: EvaluationResult
+  conditions: AllowedConditionExpression
+}
+
+export type PrincipalAccountTrust =
+  | { trustType: 'Implicit' }
+  | { trustType: 'Explicit'; statements: StatementAnalysis[] }
+  | { trustType: 'None' }
+
 /**
  * The default authorizer for services.
  */
@@ -99,7 +127,6 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
     const rcpResult = request.rcpAnalysis.result
     const identityStatementResult = request.identityAnalysis.result
     const resourcePolicyResult = request.resourceAnalysis?.result
-    const permissionBoundaryResult = request.permissionBoundaryAnalysis?.result
     const endpointPolicyResult = request.endpointAnalysis?.result
 
     const requestPrincipal = request.request.principal
@@ -136,8 +163,9 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
     }
     assertAuthenticatedRequestPrincipal(requestPrincipal)
 
-    const coreResult = this.initialEvaluationResult(request)
-    const blockedByLog = new BlockedByLog(coreResult)
+    const initialEvaluation = this.initialEvaluationResult(request)
+    let coreConditions = initialEvaluation.conditions
+    const blockedByLog = new BlockedByLog(initialEvaluation.result)
 
     blockedByLog.add('scp', scpResult)
     blockedByLog.add('rcp', rcpResult)
@@ -160,66 +188,14 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
       blockedByLog.add('identity', 'ExplicitlyDenied')
     }
 
-    if (permissionBoundaryResult === 'ExplicitlyDenied') {
-      blockedByLog.add('pb', 'ExplicitlyDenied')
-    }
-
-    //Same Account
-    if (sameAccount) {
-      if (permissionBoundaryResult === 'ImplicitlyDenied') {
-        /**
-         * If the permission boundary is an implicit deny
-         *
-         * If the request is from an assumed role ARN AND the resource policy allows the assumed role (session) ARN = ALLOW
-         * If the request is from an IAM user ARN AND the resource policy allows the IAM user ARN = ALLOW
-         * If the request is from a federated user ARN AND the resource policy allows the federated user ARN = ALLOW
-         * The request is allowed: https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html
-         */
-        if (resourcePolicyResult === 'Allowed') {
-          const principal = requestPrincipal.value()
-          if (
-            isAssumedRoleArn(principal) ||
-            isIamUserArn(principal) ||
-            isFederatedUserArn(principal)
-          ) {
-            // If the resource policy allows the principal directly (including via a wildcard Principal),
-            // the permission boundary implicit deny does not apply for same-account requests.
-            if (
-              !request.resourceAnalysis.allowStatements.some(
-                (statement) => statement.principalMatch === 'Match'
-              )
-            ) {
-              blockedByLog.add('pb', 'ImplicitlyDenied')
-            }
-          } else if (isIamRoleArn(principal)) {
-            // For IAM role ARNs, the permission boundary implicit deny is bypassed if
-            // * The resource policy grants access via a wildcard principal ("*"), or
-            // * In discovery mode when a session ARN in the resource policy was matched by ignoring the session name.
-            if (
-              !request.resourceAnalysis.allowStatements.some(
-                (statement) =>
-                  statement.principalMatch === 'Match' &&
-                  (statement.ignoredRoleSessionName ||
-                    (statement.statement.isPrincipalStatement() &&
-                      statement.statement.principals().some((p) => p.isWildcardPrincipal())))
-              )
-            ) {
-              blockedByLog.add('pb', 'ImplicitlyDenied')
-            }
-          } else {
-            // Service principals or other principal types: permission boundary implicit deny applies.
-            blockedByLog.add('pb', 'ImplicitlyDenied')
-          }
-        } else {
-          // Resource policy doesn't allow the principal, so the permission boundary implicit deny applies.
-          blockedByLog.add('pb', 'ImplicitlyDenied')
-        }
-      }
-    } else {
-      //Cross Account
-      if (permissionBoundaryResult === 'ImplicitlyDenied') {
-        blockedByLog.add('pb', 'ImplicitlyDenied')
-      }
+    const permissionBoundaryMutation = this.applyPermissionBoundaryToCoreConditions(
+      request,
+      sameAccount,
+      coreConditions
+    )
+    coreConditions = permissionBoundaryMutation.conditions
+    if (permissionBoundaryMutation.result) {
+      blockedByLog.add('pb', permissionBoundaryMutation.result)
     }
 
     const blockedReasons = blockedByLog.getBlockedBy()
@@ -227,9 +203,11 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
       baseResult.blockedBy = blockedReasons
     }
 
+    const finalResult = blockedByLog.getResult()
     return {
-      result: blockedByLog.getResult(),
-      ...baseResult
+      result: finalResult,
+      ...baseResult,
+      conditions: this.conditionsForAllowedResult(request, coreConditions, finalResult)
     }
 
     /**
@@ -262,8 +240,8 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
     >
   ): RequestAnalysis {
     const endpointPolicyResult = request.endpointAnalysis?.result
-    const coreResult = this.anonymousInitialEvaluationResult(request)
-    const blockedByLog = new BlockedByLog(coreResult)
+    const initialEvaluation = this.anonymousInitialEvaluationResult(request)
+    const blockedByLog = new BlockedByLog(initialEvaluation.result)
 
     if (request.rcpAnalysis.ouAnalysis.length > 0) {
       blockedByLog.add('rcp', request.rcpAnalysis.result)
@@ -281,10 +259,16 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
       baseResult.blockedBy = blockedReasons
     }
 
+    const finalResult = blockedByLog.getResult()
     return {
-      result: blockedByLog.getResult(),
+      result: finalResult,
       ...baseResult,
-      sameAccount: false
+      sameAccount: false,
+      conditions: this.conditionsForAllowedResult(
+        request,
+        initialEvaluation.conditions,
+        finalResult
+      )
     }
   }
 
@@ -294,18 +278,29 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
    * @param request the service authorization request containing all analyses.
    * @returns the core anonymous result before applicable resource-side guardrails are applied.
    */
-  private anonymousInitialEvaluationResult(request: ServiceAuthorizationRequest): EvaluationResult {
+  private anonymousInitialEvaluationResult(
+    request: ServiceAuthorizationRequest
+  ): InitialEvaluation {
     const resourcePolicyResult = request.resourceAnalysis?.result
     if (resourcePolicyResult === 'Allowed') {
-      return 'Allowed'
+      return {
+        result: 'Allowed',
+        conditions: resourceAllowStatementsExpression(request.resourceAnalysis.allowStatements)
+      }
     }
     if (
       resourcePolicyResult === 'ExplicitlyDenied' ||
       resourcePolicyResult === 'DeniedForAccount'
     ) {
-      return 'ExplicitlyDenied'
+      return {
+        result: 'ExplicitlyDenied',
+        conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+      }
     }
-    return 'ImplicitlyDenied'
+    return {
+      result: 'ImplicitlyDenied',
+      conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+    }
   }
 
   /**
@@ -319,14 +314,467 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
     sameAccount: boolean,
     resourceAnalysis: ResourceAnalysis,
     resource: RequestResource
-  ): boolean {
+  ): PrincipalAccountTrust {
     if (sameAccount) {
-      return true
+      return { trustType: 'Implicit' }
     }
 
-    return resourceAnalysis.allowStatements.some(
+    const accountLevelStatements = this.accountLevelResourceAllowStatements(resourceAnalysis)
+    if (accountLevelStatements.length > 0) {
+      return { trustType: 'Explicit', statements: accountLevelStatements }
+    }
+
+    return { trustType: 'None' }
+  }
+
+  /**
+   * Combine core authorization conditions with guardrail conditions for a final allowed result.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param coreConditions the conditions for the core service authorization decision after permission-boundary mutation
+   * @param finalResult the final authorization result after guardrails
+   * @returns the public conditions expression, or undefined when none should be emitted
+   */
+  protected conditionsForAllowedResult(
+    request: ServiceAuthorizationRequest,
+    coreConditions: AllowedConditionExpression,
+    finalResult: EvaluationResult
+  ): AllowedConditionExpression | undefined {
+    const expressions = [
+      sessionPolicyExpression(request.sessionAnalysis, request.sessionAnalysis !== undefined),
+      coreConditions,
+      request.scpAnalysis.conditions,
+      request.rcpAnalysis.conditions
+    ]
+
+    if (request.endpointAnalysis?.result === 'Allowed') {
+      expressions.push(endpointPolicyExpression(request.endpointAnalysis))
+    }
+
+    expressions.push(
+      ...allDenyEscapeExpressions({
+        sessionAnalysis: request.sessionAnalysis,
+        scpAnalysis: request.scpAnalysis,
+        rcpAnalysis: request.rcpAnalysis,
+        identityAnalysis: request.identityAnalysis,
+        resourceAnalysis: request.resourceAnalysis,
+        permissionBoundaryAnalysis: request.permissionBoundaryAnalysis,
+        endpointAnalysis: request.endpointAnalysis
+      })
+    )
+
+    return allowedConditionOutput(
+      and(expressions),
+      request.simulationParameters.simulationMode,
+      finalResult
+    )
+  }
+
+  /**
+   * Apply permission-boundary effects to the core authorization conditions.
+   *
+   * Permission boundaries are not part of the core service authorization result. This function lives
+   * with the permission-boundary authorization checks and recalculates the affected condition paths
+   * only when permission-boundary behavior changes which core path can be used.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param sameAccount whether the principal and resource are in the same account
+   * @param coreConditions the unmodified core authorization conditions
+   * @returns the permission-boundary block result, if any, and updated core conditions
+   */
+  private applyPermissionBoundaryToCoreConditions(
+    request: ServiceAuthorizationRequest,
+    sameAccount: boolean,
+    coreConditions: AllowedConditionExpression
+  ): PermissionBoundaryMutation {
+    const permissionBoundaryResult = request.permissionBoundaryAnalysis?.result
+    if (!permissionBoundaryResult) {
+      return { conditions: coreConditions }
+    }
+
+    if (permissionBoundaryResult === 'ExplicitlyDenied') {
+      return { result: 'ExplicitlyDenied', conditions: coreConditions }
+    }
+
+    if (permissionBoundaryResult === 'Allowed') {
+      return {
+        conditions: this.coreConditionsWithAllowedPermissionBoundary(request, sameAccount)
+      }
+    }
+
+    if (permissionBoundaryResult === 'ImplicitlyDenied') {
+      if (!sameAccount) {
+        return { result: 'ImplicitlyDenied', conditions: coreConditions }
+      }
+
+      const bypassStatements = this.permissionBoundaryBypassResourceAllowStatements(request)
+      if (bypassStatements.length === 0) {
+        return { result: 'ImplicitlyDenied', conditions: coreConditions }
+      }
+
+      return { conditions: resourceAllowStatementsExpression(bypassStatements) }
+    }
+
+    return { conditions: coreConditions }
+  }
+
+  /**
+   * Recalculate core conditions when an allowed permission boundary constrains identity-policy paths.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param sameAccount whether the principal and resource are in the same account
+   * @returns core conditions with permission-boundary allow conditions applied to identity paths
+   */
+  private coreConditionsWithAllowedPermissionBoundary(
+    request: ServiceAuthorizationRequest,
+    sameAccount: boolean
+  ): AllowedConditionExpression {
+    const principal = request.request.principal
+    if (principal.isAnonymous()) {
+      return resourceAllowStatementsExpression(request.resourceAnalysis.allowStatements)
+    }
+    assertAuthenticatedRequestPrincipal(principal)
+
+    if (isServicePrincipal(principal.value())) {
+      return resourceAllowStatementsExpression(request.resourceAnalysis.allowStatements)
+    }
+
+    if (sameAccount) {
+      const trustedAccount = this.serviceTrustsPrincipalAccount(
+        sameAccount,
+        request.resourceAnalysis,
+        request.request.resource
+      )
+      return this.sameAccountConditionsWithAllowedPermissionBoundary(request, trustedAccount)
+    }
+
+    if (
+      (request.resourceAnalysis.result === 'Allowed' ||
+        request.resourceAnalysis.result === 'AllowedForAccount') &&
+      request.identityAnalysis.result === 'Allowed'
+    ) {
+      return and([
+        this.crossAccountResourcePolicyConditions(request),
+        identityPolicyExpression(request.identityAnalysis),
+        permissionBoundaryExpression(request.permissionBoundaryAnalysis)
+      ])
+    }
+
+    return { conditionType: 'never', reason: 'noApplicableAllow' }
+  }
+
+  /**
+   * Recalculate same-account conditions when an allowed permission boundary constrains identity paths.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param trustedAccount how the service trusts the principal account for this request
+   * @returns same-account core conditions with permission-boundary allow conditions applied to identity paths
+   */
+  private sameAccountConditionsWithAllowedPermissionBoundary(
+    request: ServiceAuthorizationRequest,
+    trustedAccount: PrincipalAccountTrust
+  ): AllowedConditionExpression {
+    switch (trustedAccount.trustType) {
+      case 'Implicit':
+        return this.sameAccountImplicitTrustConditionsWithAllowedPermissionBoundary(request)
+      case 'Explicit':
+        return this.sameAccountExplicitTrustConditionsWithAllowedPermissionBoundary(
+          request,
+          trustedAccount
+        )
+      case 'None':
+        return request.resourceAnalysis.result === 'Allowed'
+          ? this.sameAccountResourcePolicyConditions(request)
+          : { conditionType: 'never', reason: 'noApplicableAllow' }
+      default:
+        throw new Error(
+          `Unrecognized principal account trust type: ${String((trustedAccount as { trustType: unknown }).trustType)}`
+        )
+    }
+  }
+
+  /**
+   * Recalculate same-account implicit trust conditions when permission-boundary allow constrains identity paths.
+   *
+   * @param request the service authorization request containing all analyses
+   * @returns same-account implicit trust conditions with permission-boundary allow conditions applied to identity paths
+   */
+  private sameAccountImplicitTrustConditionsWithAllowedPermissionBoundary(
+    request: ServiceAuthorizationRequest
+  ): AllowedConditionExpression {
+    const resourceConditions =
+      request.resourceAnalysis.result === 'Allowed'
+        ? this.sameAccountResourcePolicyConditions(request)
+        : { conditionType: 'never' as const, reason: 'noApplicableAllow' as const }
+    const identityConditions =
+      request.identityAnalysis.result === 'Allowed'
+        ? and([
+            identityPolicyExpression(request.identityAnalysis),
+            permissionBoundaryExpression(request.permissionBoundaryAnalysis)
+          ])
+        : { conditionType: 'never' as const, reason: 'noApplicableAllow' as const }
+
+    return or([resourceConditions, identityConditions])
+  }
+
+  /**
+   * Recalculate same-account explicit trust conditions when permission-boundary allow constrains identity paths.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param trustedAccount explicit account-trust statements selected by the service authorizer
+   * @returns same-account explicit trust conditions with permission-boundary allow conditions applied to identity paths
+   */
+  private sameAccountExplicitTrustConditionsWithAllowedPermissionBoundary(
+    request: ServiceAuthorizationRequest,
+    trustedAccount: Extract<PrincipalAccountTrust, { trustType: 'Explicit' }>
+  ): AllowedConditionExpression {
+    const resourceConditions =
+      request.resourceAnalysis.result === 'Allowed'
+        ? this.sameAccountResourcePolicyConditions(request)
+        : { conditionType: 'never' as const, reason: 'noApplicableAllow' as const }
+    const identityConditions =
+      request.identityAnalysis.result === 'Allowed'
+        ? and([
+            resourceAllowStatementsExpression(trustedAccount.statements),
+            identityPolicyExpression(request.identityAnalysis),
+            permissionBoundaryExpression(request.permissionBoundaryAnalysis)
+          ])
+        : { conditionType: 'never' as const, reason: 'noApplicableAllow' as const }
+
+    return or([resourceConditions, identityConditions])
+  }
+
+  /**
+   * Get resource-policy allow statements that matched the principal directly.
+   *
+   * @param resourceAnalysis resource-policy analysis containing already-matched allow statements
+   * @returns direct principal-match resource allow statements
+   */
+  private directResourceAllowStatements(resourceAnalysis: ResourceAnalysis): StatementAnalysis[] {
+    return resourceAnalysis.allowStatements.filter((statement) =>
+      ['Match', 'SessionRoleMatch', 'SessionUserMatch'].includes(statement.principalMatch)
+    )
+  }
+
+  /**
+   * Get resource-policy allow statements that matched at the principal-account level.
+   *
+   * @param resourceAnalysis resource-policy analysis containing already-matched allow statements
+   * @returns account-level resource allow statements
+   */
+  protected accountLevelResourceAllowStatements(
+    resourceAnalysis: ResourceAnalysis
+  ): StatementAnalysis[] {
+    return resourceAnalysis.allowStatements.filter(
       (statement) => statement.principalMatch === 'AccountLevelMatch'
     )
+  }
+
+  /**
+   * Get same-account resource-policy conditions for paths that can satisfy core authorization.
+   *
+   * @param request the service authorization request containing all analyses
+   * @returns resource-policy conditions for the allowed same-account branch
+   */
+  private sameAccountResourcePolicyConditions(
+    request: ServiceAuthorizationRequest
+  ): AllowedConditionExpression {
+    return resourceAllowStatementsExpression(
+      this.directResourceAllowStatements(request.resourceAnalysis)
+    )
+  }
+
+  /**
+   * Evaluate same-account core authorization and conditions based on principal-account trust.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param trustedAccount how the service trusts the principal account for this request
+   * @returns the same-account core authorization result and conditions
+   */
+  private sameAccountInitialEvaluation(
+    request: ServiceAuthorizationRequest,
+    trustedAccount: PrincipalAccountTrust
+  ): InitialEvaluation {
+    switch (trustedAccount.trustType) {
+      case 'Implicit':
+        return this.sameAccountImplicitTrustEvaluation(request)
+      case 'Explicit':
+        return this.sameAccountExplicitTrustEvaluation(request, trustedAccount)
+      case 'None':
+        return this.sameAccountNoTrustEvaluation(request)
+      default:
+        throw new Error(
+          `Unrecognized principal account trust type: ${String((trustedAccount as { trustType: unknown }).trustType)}`
+        )
+    }
+  }
+
+  /**
+   * Evaluate same-account authorization when the service implicitly trusts identity policies.
+   *
+   * @param request the service authorization request containing all analyses
+   * @returns the same-account authorization result and conditions
+   */
+  private sameAccountImplicitTrustEvaluation(
+    request: ServiceAuthorizationRequest
+  ): InitialEvaluation {
+    const resourcePolicyResult = request.resourceAnalysis.result
+    const identityStatementResult = request.identityAnalysis.result
+
+    if (resourcePolicyResult === 'Allowed' && identityStatementResult === 'Allowed') {
+      return {
+        result: 'Allowed',
+        conditions: or([
+          this.sameAccountResourcePolicyConditions(request),
+          identityPolicyExpression(request.identityAnalysis)
+        ])
+      }
+    }
+
+    if (resourcePolicyResult === 'Allowed') {
+      return {
+        result: 'Allowed',
+        conditions: this.sameAccountResourcePolicyConditions(request)
+      }
+    }
+
+    if (identityStatementResult === 'Allowed') {
+      return {
+        result: 'Allowed',
+        conditions: identityPolicyExpression(request.identityAnalysis)
+      }
+    }
+
+    return {
+      result: 'ImplicitlyDenied',
+      conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+    }
+  }
+
+  /**
+   * Evaluate same-account authorization when the service requires explicit resource-policy account trust.
+   *
+   * @param request the service authorization request containing all analyses
+   * @param trustedAccount explicit account-trust statements selected by the service authorizer
+   * @returns the same-account authorization result and conditions
+   */
+  private sameAccountExplicitTrustEvaluation(
+    request: ServiceAuthorizationRequest,
+    trustedAccount: Extract<PrincipalAccountTrust, { trustType: 'Explicit' }>
+  ): InitialEvaluation {
+    const resourcePolicyResult = request.resourceAnalysis.result
+    const identityStatementResult = request.identityAnalysis.result
+    const resourceConditions =
+      resourcePolicyResult === 'Allowed'
+        ? this.sameAccountResourcePolicyConditions(request)
+        : { conditionType: 'never' as const, reason: 'noApplicableAllow' as const }
+
+    if (identityStatementResult === 'Allowed') {
+      const identityConditions = and([
+        resourceAllowStatementsExpression(trustedAccount.statements),
+        identityPolicyExpression(request.identityAnalysis)
+      ])
+      return {
+        result: 'Allowed',
+        conditions: or([resourceConditions, identityConditions])
+      }
+    }
+
+    if (resourcePolicyResult === 'Allowed') {
+      return {
+        result: 'Allowed',
+        conditions: resourceConditions
+      }
+    }
+
+    return {
+      result: 'ImplicitlyDenied',
+      conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+    }
+  }
+
+  /**
+   * Evaluate same-account authorization when the service does not trust identity policies.
+   *
+   * @param request the service authorization request containing all analyses
+   * @returns the same-account authorization result and conditions
+   */
+  private sameAccountNoTrustEvaluation(request: ServiceAuthorizationRequest): InitialEvaluation {
+    if (request.resourceAnalysis.result === 'Allowed') {
+      return {
+        result: 'Allowed',
+        conditions: this.sameAccountResourcePolicyConditions(request)
+      }
+    }
+
+    return {
+      result: 'ImplicitlyDenied',
+      conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+    }
+  }
+
+  /**
+   * Get resource-policy conditions for a cross-account request's resource-policy side.
+   *
+   * @param request the service authorization request containing all analyses
+   * @returns resource-policy conditions for the matching cross-account resource-policy statements
+   */
+  private crossAccountResourcePolicyConditions(
+    request: ServiceAuthorizationRequest
+  ): AllowedConditionExpression {
+    if (
+      request.resourceAnalysis.result !== 'Allowed' &&
+      request.resourceAnalysis.result !== 'AllowedForAccount'
+    ) {
+      return { conditionType: 'never', reason: 'noApplicableAllow' }
+    }
+
+    return resourceAllowStatementsExpression([
+      ...this.directResourceAllowStatements(request.resourceAnalysis),
+      ...this.accountLevelResourceAllowStatements(request.resourceAnalysis)
+    ])
+  }
+
+  /**
+   * Get same-account resource-policy allow statements that bypass an implicit permission-boundary deny.
+   *
+   * @param request the service authorization request containing all analyses
+   * @returns resource-policy allow statements that bypass the implicit permission-boundary deny
+   */
+  private permissionBoundaryBypassResourceAllowStatements(
+    request: ServiceAuthorizationRequest
+  ): StatementAnalysis[] {
+    if (request.resourceAnalysis.result !== 'Allowed') {
+      return []
+    }
+
+    const principal = request.request.principal
+    if (!principal.isAuthenticated()) {
+      return []
+    }
+    const principalValue = principal.value()
+
+    if (
+      isAssumedRoleArn(principalValue) ||
+      isIamUserArn(principalValue) ||
+      isFederatedUserArn(principalValue)
+    ) {
+      return request.resourceAnalysis.allowStatements.filter(
+        (statement) => statement.principalMatch === 'Match'
+      )
+    }
+
+    if (isIamRoleArn(principalValue)) {
+      return request.resourceAnalysis.allowStatements.filter(
+        (statement) =>
+          statement.principalMatch === 'Match' &&
+          (statement.ignoredRoleSessionName ||
+            (statement.statement.isPrincipalStatement() &&
+              statement.statement.principals().some((p) => p.isWildcardPrincipal())))
+      )
+    }
+
+    return []
   }
 
   /**
@@ -344,7 +792,7 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
    * @param request the service authorization request containing all analyses
    * @returns 'Allowed' if the core policies allow the request, otherwise may return 'ImplicitlyDenied' or 'ExplicitlyDenied' depending on the analyses
    */
-  private initialEvaluationResult(request: ServiceAuthorizationRequest): EvaluationResult {
+  private initialEvaluationResult(request: ServiceAuthorizationRequest): InitialEvaluation {
     const sessionResult = request.sessionAnalysis?.result
     const identityStatementResult = request.identityAnalysis.result
     const resourcePolicyResult = request.resourceAnalysis?.result
@@ -355,23 +803,31 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
       : undefined
     const resourceAccount = request.request.resource?.accountId()
     const sameAccount = principalAccount !== undefined && principalAccount === resourceAccount
-
     if (requestPrincipal.isAnonymous()) {
       return this.anonymousInitialEvaluationResult(request)
     }
     assertAuthenticatedRequestPrincipal(requestPrincipal)
 
     if (sessionResult && sessionResult !== 'Allowed') {
-      return sessionResult
+      return {
+        result: sessionResult,
+        conditions: sessionPolicyExpression(request.sessionAnalysis, true)
+      }
     }
 
     // Service Principals
     if (isServicePrincipal(requestPrincipal.value())) {
       // Service principals are allowed if the resource policy allows them
       if (resourcePolicyResult === 'Allowed') {
-        return 'Allowed'
+        return {
+          result: 'Allowed',
+          conditions: resourceAllowStatementsExpression(request.resourceAnalysis.allowStatements)
+        }
       }
-      return 'ImplicitlyDenied'
+      return {
+        result: 'ImplicitlyDenied',
+        conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+      }
     }
 
     //Same Account
@@ -381,22 +837,26 @@ export class DefaultServiceAuthorizer implements ServiceAuthorizer {
         request.resourceAnalysis,
         request.request.resource
       )
-      if (
-        resourcePolicyResult === 'Allowed' ||
-        (trustedAccount && identityStatementResult === 'Allowed')
-      ) {
-        return 'Allowed'
-      }
-      return 'ImplicitlyDenied'
+      return this.sameAccountInitialEvaluation(request, trustedAccount)
     }
 
     //Cross Account
     if (resourcePolicyResult === 'Allowed' || resourcePolicyResult === 'AllowedForAccount') {
       if (identityStatementResult === 'Allowed') {
-        return 'Allowed'
+        const coreConditions = and([
+          this.crossAccountResourcePolicyConditions(request),
+          identityPolicyExpression(request.identityAnalysis)
+        ])
+        return {
+          result: 'Allowed',
+          conditions: coreConditions
+        }
       }
     }
 
-    return 'ImplicitlyDenied'
+    return {
+      result: 'ImplicitlyDenied',
+      conditions: { conditionType: 'never', reason: 'noApplicableAllow' }
+    }
   }
 }

--- a/src/services/IamServiceAuthorizer.ts
+++ b/src/services/IamServiceAuthorizer.ts
@@ -48,7 +48,8 @@ export class IamServiceAuthorizer extends DefaultServiceAuthorizer {
     ) {
       return {
         ...baseResult,
-        result: 'ImplicitlyDenied'
+        result: 'ImplicitlyDenied',
+        conditions: undefined
       }
     }
 
@@ -60,7 +61,8 @@ export class IamServiceAuthorizer extends DefaultServiceAuthorizer {
     ) {
       return {
         ...baseResult,
-        result: 'ImplicitlyDenied'
+        result: 'ImplicitlyDenied',
+        conditions: undefined
       }
     }
 

--- a/src/services/KmsServiceAuthorizer.ts
+++ b/src/services/KmsServiceAuthorizer.ts
@@ -1,6 +1,6 @@
 import { type ResourceAnalysis } from '../evaluate.js'
 import { type RequestResource } from '../request/requestResource.js'
-import { DefaultServiceAuthorizer } from './DefaultServiceAuthorizer.js'
+import { DefaultServiceAuthorizer, type PrincipalAccountTrust } from './DefaultServiceAuthorizer.js'
 
 /**
  * The default authorizer for services.
@@ -11,18 +11,22 @@ export class KmsServiceAuthorizer extends DefaultServiceAuthorizer {
    *
    * @param sameAccount - If the principal and resource are in the same account
    * @param resourceAnalysis - The resource policy analysis
-   * @returns true if the service trusts the principal's account IAM policies
+   * @returns how the service trusts the principal's account IAM policies
    */
   override serviceTrustsPrincipalAccount(
     sameAccount: boolean,
     resourceAnalysis: ResourceAnalysis,
     resource: RequestResource
-  ): boolean {
+  ): PrincipalAccountTrust {
     if (sameAccount && resource.value() == '*') {
-      return true
+      return { trustType: 'Implicit' }
     }
-    return resourceAnalysis.allowStatements.some(
-      (statement) => statement.principalMatch === 'AccountLevelMatch'
-    )
+
+    const accountLevelStatements = this.accountLevelResourceAllowStatements(resourceAnalysis)
+    if (accountLevelStatements.length > 0) {
+      return { trustType: 'Explicit', statements: accountLevelStatements }
+    }
+
+    return { trustType: 'None' }
   }
 }

--- a/src/services/StsServiceAuthorizer.ts
+++ b/src/services/StsServiceAuthorizer.ts
@@ -1,6 +1,6 @@
 import { type RequestAnalysis, type ResourceAnalysis } from '../evaluate.js'
 import { type RequestResource } from '../request/requestResource.js'
-import { DefaultServiceAuthorizer } from './DefaultServiceAuthorizer.js'
+import { DefaultServiceAuthorizer, type PrincipalAccountTrust } from './DefaultServiceAuthorizer.js'
 import { type ServiceAuthorizationRequest } from './ServiceAuthorizer.js'
 
 /**
@@ -14,7 +14,8 @@ export class StsServiceAuthorizer extends DefaultServiceAuthorizer {
     ) {
       return {
         result: 'Allowed',
-        sameAccount: true
+        sameAccount: true,
+        conditions: undefined
       }
     }
     return super.authorize(request)
@@ -25,16 +26,16 @@ export class StsServiceAuthorizer extends DefaultServiceAuthorizer {
    *
    * @param sameAccount - If the principal and resource are in the same account
    * @param resourceAnalysis - The resource policy analysis
-   * @returns true if the service trusts the principal's account IAM policies
+   * @returns how the service trusts the principal's account IAM policies
    */
   override serviceTrustsPrincipalAccount(
     sameAccount: boolean,
     resourceAnalysis: ResourceAnalysis,
     resource: RequestResource
-  ): boolean {
+  ): PrincipalAccountTrust {
     //If there is no resource policy, the service trusts the principal's account IAM policies
     if (sameAccount && resourceAnalysis.result === 'NotApplicable') {
-      return true
+      return { trustType: 'Implicit' }
     }
 
     /*
@@ -42,8 +43,11 @@ export class StsServiceAuthorizer extends DefaultServiceAuthorizer {
       the trust policy must explicitly allow the principal's account,
       even if the principal and resource are in the same account.
     */
-    return resourceAnalysis.allowStatements.some(
-      (statement) => statement.principalMatch === 'AccountLevelMatch'
-    )
+    const accountLevelStatements = this.accountLevelResourceAllowStatements(resourceAnalysis)
+    if (accountLevelStatements.length > 0) {
+      return { trustType: 'Explicit', statements: accountLevelStatements }
+    }
+
+    return { trustType: 'None' }
   }
 }

--- a/src/services/s3/S3ServiceAuthorizer.ts
+++ b/src/services/s3/S3ServiceAuthorizer.ts
@@ -52,7 +52,8 @@ export class S3ServiceAuthorizer extends DefaultServiceAuthorizer {
     return {
       ...baseResult,
       result: 'ExplicitlyDenied',
-      blockedBy: ['s3-bpa']
+      blockedBy: ['s3-bpa'],
+      conditions: undefined
     }
   }
 }

--- a/src/simulation_engine/simulationEngineIntegration.test.ts
+++ b/src/simulation_engine/simulationEngineIntegration.test.ts
@@ -10,6 +10,7 @@ interface ExpectedResult {
   resourceType?: string
   resourcePattern?: string
   result?: string
+  conditions?: unknown
 }
 
 interface IntegrationTestCase {
@@ -76,11 +77,22 @@ describe('simulationEngineIntegration', () => {
             )
           }
 
+          if (response.resultType === 'single') {
+            if (testCase.expected.results[0]?.conditions) {
+              expect(response.result.analysis.conditions).toEqual(
+                testCase.expected.results[0].conditions
+              )
+            } else {
+              expect(response.result.analysis.conditions, 'unexpected conditions').toBeUndefined()
+            }
+          }
+
           if (response.resultType === 'wildcard') {
             const normalizedResults: ExpectedResult[] = response.results.map((result) => ({
               resourceType: result.resourceType,
               resourcePattern: result.resourcePattern,
-              result: result.analysis?.result
+              result: result.analysis?.result,
+              ...(result.analysis.conditions ? { conditions: result.analysis.conditions } : {})
             }))
 
             const expectedResults = [...testCase.expected.results]

--- a/src/simulation_engine/simulationEngineIntegrationTests/contextKeys/discoveryContextKeyConstraints.json
+++ b/src/simulation_engine/simulationEngineIntegrationTests/contextKeys/discoveryContextKeyConstraints.json
@@ -11,7 +11,11 @@
                 "Effect": "Allow",
                 "Action": "s3:GetObject",
                 "Resource": "arn:aws:s3:::example-bucket/object.txt",
-                "Condition": { "StringEquals": { "aws:SourceAccount": "111111111111" } }
+                "Condition": {
+                  "StringEquals": {
+                    "aws:SourceAccount": "111111111111"
+                  }
+                }
               }
             ]
           }
@@ -26,19 +30,42 @@
           "accountId": "123456789012"
         },
         "principal": "arn:aws:iam::123456789012:user/Alice",
-        "contextVariables": { "aws:SourceAccount": "000000000000" }
+        "contextVariables": {
+          "aws:SourceAccount": "000000000000"
+        }
       }
     },
     "simulationOptions": {
       "simulationMode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SourceAccount", "presenceIsKnown": true, "valueIsKnown": false }
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
       ]
     },
     "expected": {
       "resultType": "single",
       "overallResult": "Allowed",
-      "results": []
+      "results": [
+        {
+          "conditions": {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceAccount",
+            "values": ["111111111111"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "source-account-allow",
+                "policyType": "identity",
+                "statementIndex": 1
+              }
+            ]
+          }
+        }
+      ]
     }
   },
   {
@@ -58,7 +85,11 @@
                 "Effect": "Deny",
                 "Action": "s3:GetObject",
                 "Resource": "arn:aws:s3:::example-bucket/*",
-                "Condition": { "StringEquals": { "aws:SourceAccount": "111111111111" } }
+                "Condition": {
+                  "StringEquals": {
+                    "aws:SourceAccount": "111111111111"
+                  }
+                }
               }
             ]
           }
@@ -68,15 +99,24 @@
       "resourceControlPolicies": [],
       "request": {
         "action": "s3:GetObject",
-        "resource": { "resource": "arn:aws:s3:::example-bucket/*", "accountId": "123456789012" },
+        "resource": {
+          "resource": "arn:aws:s3:::example-bucket/*",
+          "accountId": "123456789012"
+        },
         "principal": "arn:aws:iam::123456789012:user/Alice",
-        "contextVariables": { "aws:SourceAccount": "000000000000" }
+        "contextVariables": {
+          "aws:SourceAccount": "000000000000"
+        }
       }
     },
     "simulationOptions": {
       "simulationMode": "Discovery",
       "discoveryContextKeyConstraints": [
-        { "keyName": "aws:SourceAccount", "presenceIsKnown": true, "valueIsKnown": false }
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
       ]
     },
     "expected": {
@@ -86,7 +126,118 @@
         {
           "resourceType": "object",
           "resourcePattern": "arn:aws:s3:::example-bucket/*",
-          "result": "Allowed"
+          "result": "Allowed",
+          "conditions": {
+            "conditionType": "condition",
+            "op": "StringNotEquals",
+            "key": "aws:SourceAccount",
+            "values": ["111111111111"],
+            "sources": [
+              {
+                "effect": "Deny",
+                "policyIdentifier": "source-account-deny",
+                "policyType": "identity",
+                "statementIndex": 2
+              }
+            ],
+            "inverted": true
+          }
+        }
+      ]
+    }
+  },
+  {
+    "name": "single resource inverts ForAllValues deny condition with known presence and unknown value",
+    "simulation": {
+      "identityPolicies": [
+        {
+          "name": "source-orgpaths-deny",
+          "policy": {
+            "Statement": [
+              {
+                "Effect": "Allow",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::example-bucket/object.txt"
+              },
+              {
+                "Effect": "Deny",
+                "Action": "s3:GetObject",
+                "Resource": "arn:aws:s3:::example-bucket/object.txt",
+                "Condition": {
+                  "ForAllValues:StringEquals": {
+                    "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/*"]
+                  }
+                }
+              }
+            ]
+          }
+        }
+      ],
+      "serviceControlPolicies": [],
+      "resourceControlPolicies": [],
+      "request": {
+        "action": "s3:GetObject",
+        "resource": {
+          "resource": "arn:aws:s3:::example-bucket/object.txt",
+          "accountId": "123456789012"
+        },
+        "principal": "arn:aws:iam::123456789012:user/Alice",
+        "contextVariables": {
+          "aws:SourceOrgPaths": ["o-abc/r-root/ou-team/app"]
+        }
+      }
+    },
+    "simulationOptions": {
+      "simulationMode": "Discovery",
+      "discoveryContextKeyConstraints": [
+        {
+          "keyName": "aws:SourceOrgPaths",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
+      ]
+    },
+    "expected": {
+      "resultType": "single",
+      "overallResult": "Allowed",
+      "results": [
+        {
+          "conditions": {
+            "conditionType": "group",
+            "operator": "and",
+            "conditions": [
+              {
+                "conditionType": "condition",
+                "op": "Null",
+                "key": "aws:SourceOrgPaths",
+                "values": ["false"],
+                "sources": [
+                  {
+                    "effect": "Deny",
+                    "policyIdentifier": "source-orgpaths-deny",
+                    "policyType": "identity",
+                    "statementIndex": 2
+                  }
+                ],
+                "inverted": true
+              },
+              {
+                "conditionType": "condition",
+                "op": "ForAnyValue:StringNotEquals",
+                "key": "aws:SourceOrgPaths",
+                "values": ["o-abc/r-root/ou-team/*"],
+                "sources": [
+                  {
+                    "effect": "Deny",
+                    "policyIdentifier": "source-orgpaths-deny",
+                    "policyType": "identity",
+                    "statementIndex": 2
+                  }
+                ],
+                "inverted": true
+              }
+            ]
+          }
         }
       ]
     }


### PR DESCRIPTION
## Summary

Adds structured `conditions` output for Discovery-mode final `Allowed` analyses so callers can understand the condition expression under which access is allowed.

- Adds public `AllowedConditionExpression` types on `RequestAnalysis.conditions`
- Keeps legacy `ignoredConditions`
- Emits `conditions` only for Discovery-mode final `Allowed` results when access depends on ignored unknown conditions/session names
- Supports allow condition conversion, deny inversion, AND/OR simplification, role session-name conditions, SCP/RCP conditions, permission-boundary mutation, endpoints, KMS/STS/IAM/S3 service-authorizer behavior
- Adds focused core-engine matrix coverage plus simulation integration assertions

## Validation

- `npm run build`
- `npm test` — 46 files, 1429 passed, 1 todo
- `npm run format-check`
