### PR TITLE
fix: resolve sub-resource arns to specific resource type

### DIFF
--- a/src/simulation_engine/resourceTypes.test.ts
+++ b/src/simulation_engine/resourceTypes.test.ts
@@ -33,4 +33,110 @@ describe('getResourceTypesForAction', () => {
     //Then the result should be returned
     expect(result).toEqual([])
   })
+
+  it('should return only the sub-resource type when a sub-resource ARN also matches its parent', async () => {
+    //Given a DynamoDB stream ARN and an action valid for both the table and the stream
+    const service = 'dynamodb'
+    const action = 'GetResourcePolicy'
+    const resource =
+      'arn:aws:dynamodb:us-east-1:123456789012:table/synthetic-table/stream/2026-02-17T14:10:55.441'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then only the stream type is returned, not the table type it also matches
+    expect(result.map((rt) => rt.key)).toEqual(['stream'])
+  })
+
+  it('should return the parent type for a parent ARN', async () => {
+    //Given a DynamoDB table ARN and an action valid for both the table and the stream
+    const service = 'dynamodb'
+    const action = 'GetResourcePolicy'
+    const resource = 'arn:aws:dynamodb:us-east-1:123456789012:table/synthetic-table'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then only the table type is returned
+    expect(result.map((rt) => rt.key)).toEqual(['table'])
+  })
+
+  it('should return only the sub-resource type when the sub-resource is colon-delimited', async () => {
+    //Given a Batch job-definition revision ARN, whose qualifier is appended with ':'
+    const service = 'batch'
+    const action = 'SubmitJob'
+    const resource = 'arn:aws:batch:us-east-1:123456789012:job-definition/synthetic-definition:3'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then only the revision type is returned, not the job-definition type it also matches
+    expect(result.map((rt) => rt.key)).toEqual(['job-definition-revision'])
+  })
+
+  it('should return the parent type for a colon-delimited parent ARN', async () => {
+    //Given an unqualified Batch job-definition ARN
+    const service = 'batch'
+    const action = 'SubmitJob'
+    const resource = 'arn:aws:batch:us-east-1:123456789012:job-definition/synthetic-definition'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then only the job-definition type is returned
+    expect(result.map((rt) => rt.key)).toEqual(['job-definition'])
+  })
+
+  it('should return only the sub-resource type when the parent pattern ends with a delimiter', async () => {
+    //Given a Cassandra table ARN, whose keyspace parent pattern ends with a trailing slash
+    const service = 'cassandra'
+    const action = 'Alter'
+    const resource =
+      'arn:aws:cassandra:us-east-1:123456789012:/keyspace/synthetic-keyspace/table/synthetic-table'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then only the table type is returned, not the keyspace type it also matches
+    expect(result.map((rt) => rt.key)).toEqual(['table'])
+  })
+
+  it('should return the parent type for a parent ARN ending with a delimiter', async () => {
+    //Given a Cassandra keyspace ARN, which genuinely ends with a trailing slash
+    const service = 'cassandra'
+    const action = 'Alter'
+    const resource = 'arn:aws:cassandra:us-east-1:123456789012:/keyspace/synthetic-keyspace/'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then only the keyspace type is returned
+    expect(result.map((rt) => rt.key)).toEqual(['keyspace'])
+  })
+
+  it('should keep every matching type for a wildcard resource', async () => {
+    //Given a wildcard DynamoDB resource that names tables and their streams alike
+    const service = 'dynamodb'
+    const action = 'GetResourcePolicy'
+    const resource = 'arn:aws:dynamodb:us-east-1:123456789012:table/*'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then the ambiguity is preserved so the engine simulates each type
+    expect(new Set(result.map((rt) => rt.key))).toEqual(new Set(['table', 'stream']))
+  })
+
+  it('should return the object type for an S3 object key containing slashes', async () => {
+    //Given an S3 object key with slashes, which the bucket pattern must not claim
+    const service = 's3'
+    const action = 'GetObject'
+    const resource = 'arn:aws:s3:::bucket/nested/path/object.txt'
+
+    //When the resource types are gotten
+    const result = await getResourceTypesForAction(service, action, resource)
+
+    //Then the object type is returned
+    expect(result.map((rt) => rt.key)).toEqual(['object'])
+  })
 })

--- a/src/simulation_engine/resourceTypes.ts
+++ b/src/simulation_engine/resourceTypes.ts
@@ -34,5 +34,50 @@ export async function getResourceTypesForAction(
     }
   }
 
-  return matchingResourceTypes
+  // A wildcard resource can genuinely match multiple resource types, such as a
+  // DynamoDB `table/*` resource matching tables and streams alike. Preserve all
+  // matches so the simulation engine can evaluate each candidate type.
+  if (resource.includes('*')) {
+    return matchingResourceTypes
+  }
+
+  return dropSupersededResourceTypes(matchingResourceTypes)
+}
+
+/**
+ * Drop resource type matches that are refined by a more specific matched type.
+ *
+ * Resource type matching allows a trailing variable segment to span delimiters
+ * so S3 object keys can contain `/`. That also means a concrete sub-resource ARN
+ * can match its parent type, such as a DynamoDB stream matching both `stream` and
+ * `table`. When both parent and child patterns match, only the child pattern
+ * describes the concrete resource.
+ *
+ * @param matches the resource types whose ARN patterns matched the resource
+ * @returns the matching resource types that are not superseded by a child pattern
+ */
+function dropSupersededResourceTypes(matches: ResourceType[]): ResourceType[] {
+  return matches.filter(
+    (candidate) => !matches.some((other) => patternRefines(other.arn, candidate.arn))
+  )
+}
+
+/**
+ * Determine whether one resource type pattern extends another pattern.
+ *
+ * Sub-resources and qualified ARNs can be delimited with either `/` or `:`. Some
+ * parent patterns already end in one of those delimiters, so the candidate
+ * delimiter is normalized before testing the prefix relationship.
+ *
+ * @param other the potentially more specific ARN pattern
+ * @param candidate the potentially superseded ARN pattern
+ * @returns true when `other` extends `candidate` with additional ARN segments
+ */
+function patternRefines(other: string, candidate: string): boolean {
+  if (other === candidate) {
+    return false
+  }
+
+  const candidateBase = candidate.replace(/[/:]$/, '')
+  return other.startsWith(`${candidateBase}/`) || other.startsWith(`${candidateBase}:`)
 }


### PR DESCRIPTION
## Summary

Fixes concrete sub-resource ARN resolution so a child resource type supersedes a parent type when both ARN patterns match the same concrete resource.

The matcher still allows trailing variables to span delimiters for S3 object key support, but `getResourceTypesForAction` now post-filters concrete-resource matches to drop parent patterns refined by a more specific slash- or colon-delimited pattern. Wildcard resources continue to preserve all matching types for multi-simulation.

## Tests

Added sanitized regression coverage for:
- DynamoDB stream ARN resolving to `stream` instead of both `stream` and `table`
- Batch job-definition revision resolving to `job-definition-revision`
- Cassandra parent patterns with trailing delimiters
- Wildcard resources preserving all matches
- S3 object keys containing slashes resolving to `object`

## Commands run

- `npx vitest --run src/simulation_engine/resourceTypes.test.ts`
- `npm run build`
- `npm test`
- `npm run format-check`

