### PR TITLE
fix: use iam-utils resource type reducer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",
         "@cloud-copilot/iam-policy": "^0.1.89",
-        "@cloud-copilot/iam-utils": "^0.1.54"
+        "@cloud-copilot/iam-utils": "^0.1.78"
       },
       "devDependencies": {
         "@cloud-copilot/prettier-config": "^0.1.1",
@@ -172,9 +172,9 @@
       "license": "AGPL-3.0-or-later"
     },
     "node_modules/@cloud-copilot/iam-utils": {
-      "version": "0.1.75",
-      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-utils/-/iam-utils-0.1.75.tgz",
-      "integrity": "sha512-oX84ujkfYgyYw2H69jzBsGpitG+bNorhWug45ZoBCOtFGV5Zc+j6ADT2g5DSJeJ/HLwCHfGZXeqcD3Pr3Dq+7w==",
+      "version": "0.1.78",
+      "resolved": "https://registry.npmjs.org/@cloud-copilot/iam-utils/-/iam-utils-0.1.78.tgz",
+      "integrity": "sha512-9heAu67B2yUxdPSwHNXQInRo6WQhTgJ9xY9HHrdrPqIg3j9SW0uqAJkmJQPqRF13XJKId/b2yxeiC31tAKBlkA==",
       "license": "AGPL-3.0-or-later"
     },
     "node_modules/@cloud-copilot/prettier-config": {

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   "dependencies": {
     "@cloud-copilot/iam-data": ">=0.15.202511222 <1.0.0",
     "@cloud-copilot/iam-policy": "^0.1.89",
-    "@cloud-copilot/iam-utils": "^0.1.54"
+    "@cloud-copilot/iam-utils": "^0.1.78"
   },
   "prettier": "@cloud-copilot/prettier-config",
   "release": {

--- a/src/simulation_engine/resourceTypes.ts
+++ b/src/simulation_engine/resourceTypes.ts
@@ -3,7 +3,7 @@ import {
   iamResourceTypeDetails,
   type ResourceType
 } from '@cloud-copilot/iam-data'
-import { resourceStringMatchesResourceTypePattern } from '@cloud-copilot/iam-utils'
+import { mostSpecificMatchingResourceTypePatterns } from '@cloud-copilot/iam-utils'
 
 /**
  * Get the the possible resource types for an action and resource
@@ -23,61 +23,15 @@ export async function getResourceTypesForAction(
     throw new Error(`${service}:${action} does not have any resource types`)
   }
 
-  const matchingResourceTypes: ResourceType[] = []
+  const actionResourceTypes: ResourceType[] = []
   for (const rt of actionDetails.resourceTypes) {
-    const resourceType = await iamResourceTypeDetails(service, rt.name)
-    // const pattern = convertResourcePatternToRegex(resourceType.arn)
-    // const match = resource.match(new RegExp(pattern))
-    const match = resourceStringMatchesResourceTypePattern(resource, resourceType.arn)
-    if (match) {
-      matchingResourceTypes.push(resourceType)
-    }
+    actionResourceTypes.push(await iamResourceTypeDetails(service, rt.name))
   }
 
-  // A wildcard resource can genuinely match multiple resource types, such as a
-  // DynamoDB `table/*` resource matching tables and streams alike. Preserve all
-  // matches so the simulation engine can evaluate each candidate type.
-  if (resource.includes('*')) {
-    return matchingResourceTypes
-  }
-
-  return dropSupersededResourceTypes(matchingResourceTypes)
-}
-
-/**
- * Drop resource type matches that are refined by a more specific matched type.
- *
- * Resource type matching allows a trailing variable segment to span delimiters
- * so S3 object keys can contain `/`. That also means a concrete sub-resource ARN
- * can match its parent type, such as a DynamoDB stream matching both `stream` and
- * `table`. When both parent and child patterns match, only the child pattern
- * describes the concrete resource.
- *
- * @param matches the resource types whose ARN patterns matched the resource
- * @returns the matching resource types that are not superseded by a child pattern
- */
-function dropSupersededResourceTypes(matches: ResourceType[]): ResourceType[] {
-  return matches.filter(
-    (candidate) => !matches.some((other) => patternRefines(other.arn, candidate.arn))
+  const matchingPatterns = mostSpecificMatchingResourceTypePatterns(
+    resource,
+    actionResourceTypes.map((resourceType) => resourceType.arn)
   )
-}
 
-/**
- * Determine whether one resource type pattern extends another pattern.
- *
- * Sub-resources and qualified ARNs can be delimited with either `/` or `:`. Some
- * parent patterns already end in one of those delimiters, so the candidate
- * delimiter is normalized before testing the prefix relationship.
- *
- * @param other the potentially more specific ARN pattern
- * @param candidate the potentially superseded ARN pattern
- * @returns true when `other` extends `candidate` with additional ARN segments
- */
-function patternRefines(other: string, candidate: string): boolean {
-  if (other === candidate) {
-    return false
-  }
-
-  const candidateBase = candidate.replace(/[/:]$/, '')
-  return other.startsWith(`${candidateBase}/`) || other.startsWith(`${candidateBase}:`)
+  return actionResourceTypes.filter((resourceType) => matchingPatterns.includes(resourceType.arn))
 }


### PR DESCRIPTION
## Summary
- bump `@cloud-copilot/iam-utils` to `^0.1.78`
- refactor `getResourceTypesForAction` to use `mostSpecificMatchingResourceTypePatterns`
- remove local resource type superseding/refinement helpers now provided by iam-utils

## Tests
- `npx vitest --run src/simulation_engine/resourceTypes.test.ts`
- `npm test`
- `npm run format-check`
- `npm run build`
