### PR TITLE
fix: report discovery missing-key allow conditions

### DIFF
--- a/src/condition/condition.test.ts
+++ b/src/condition/condition.test.ts
@@ -2141,7 +2141,7 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       expect(result.details.conditions?.[0].matchedBecauseMissing).toBe(true)
     })
 
-    it('should not report StringEqualsIfExists as ignored when presence is unknown and the key is absent but the condition matches', () => {
+    it('should report StringEqualsIfExists as ignored when presence is unknown and the key is absent', () => {
       //Given an absent SourceAccount key whose absence is not authoritative
       const req = requestWithContext({})
       const cond = conditionsFor('Allow', {
@@ -2156,9 +2156,10 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
         discoveryWithConstraint('aws:SourceAccount', false, false)
       )
 
-      //Then the matching Allow condition should not need to be ignored
+      //Then the IfExists missing-key match should be conditional on the key remaining absent
       expect(result.matches).toBe('Match')
-      expect(result.ignoredConditions).toBeUndefined()
+      expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
+      expect(result.details.conditions?.[0].matchedBecauseMissing).toBe(true)
     })
 
     it('should report StringEqualsIfExists as ignored when presence is known but the present value is unknown', () => {
@@ -2202,7 +2203,7 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       expect(result.details.conditions?.[0].matchedBecauseMissing).toBe(true)
     })
 
-    it('should not report StringNotEqualsIfExists as ignored when presence is unknown and the key is absent but the condition matches', () => {
+    it('should report StringNotEqualsIfExists as ignored when presence is unknown and the key is absent', () => {
       //Given an absent SourceAccount key whose absence is not authoritative
       const req = requestWithContext({})
       const cond = conditionsFor('Allow', {
@@ -2217,9 +2218,10 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
         discoveryWithConstraint('aws:SourceAccount', false, false)
       )
 
-      //Then the matching Allow condition should not need to be ignored
+      //Then the IfExists missing-key match should be conditional on the key remaining absent
       expect(result.matches).toBe('Match')
-      expect(result.ignoredConditions).toBeUndefined()
+      expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
+      expect(result.details.conditions?.[0].matchedBecauseMissing).toBe(true)
     })
 
     it('should definitively not match StringEquals when presence is known and the key is absent', () => {
@@ -2257,6 +2259,25 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       //Then the condition should be conditional on the key's possible presence
       expect(result.matches).toBe('Match')
       expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
+    })
+
+    it('should report Allow StringNotEquals as ignored when an unconstrained key is absent', () => {
+      //Given an absent ResourceAccount key with no explicit discovery constraint
+      const req = requestWithContext({})
+      const cond = conditionsFor('Allow', {
+        StringNotEquals: { 's3:ResourceAccount': '111111111111' }
+      })
+
+      //When checking the condition in Discovery mode
+      const result = requestMatchesConditions(req, cond, 'Allow', {
+        simulationMode: 'Discovery',
+        discoveryContextKeyConstraints: new DiscoveryContextKeyConstraints([])
+      })
+
+      //Then the missing unconstrained key should be treated as unknown and reported as conditional
+      expect(result.matches).toBe('Match')
+      expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['s3:ResourceAccount'])
+      expect(result.details.conditions?.[0].matchedBecauseMissing).toBe(true)
     })
 
     it('should definitively match ForAllValues when presence is known and the key is absent', () => {
@@ -2322,6 +2343,25 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceOrgPaths'])
     })
 
+    it('should report Allow ForAllValues StringNotEquals as ignored when an unconstrained key is absent', () => {
+      //Given an absent SourceOrgPaths key with no explicit discovery constraint
+      const req = requestWithContext({})
+      const cond = conditionsFor('Allow', {
+        'ForAllValues:StringNotEquals': { 'aws:SourceOrgPaths': 'o-example/r-root/ou-target/' }
+      })
+
+      //When checking the condition in Discovery mode
+      const result = requestMatchesConditions(req, cond, 'Allow', {
+        simulationMode: 'Discovery',
+        discoveryContextKeyConstraints: new DiscoveryContextKeyConstraints([])
+      })
+
+      //Then ForAllValues missing-key matching should not make the negative condition unconditional
+      expect(result.matches).toBe('Match')
+      expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceOrgPaths'])
+      expect(result.details.conditions?.[0].matchedBecauseMissing).toBe(true)
+    })
+
     it('should definitively not match ForAnyValue when presence is known and the key is absent', () => {
       //Given an absent SourceOrgPaths key whose absence is authoritative
       const req = requestWithContext({})
@@ -2381,6 +2421,25 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       //Then ForAnyValue cannot definitively rely on the missing key
       expect(result.matches).toBe('Match')
       expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceOrgPaths'])
+    })
+
+    it('should report Allow ForAnyValue StringNotEquals as ignored when an unconstrained key is absent', () => {
+      //Given an absent SourceOrgPaths key with no explicit discovery constraint
+      const req = requestWithContext({})
+      const cond = conditionsFor('Allow', {
+        'ForAnyValue:StringNotEquals': { 'aws:SourceOrgPaths': 'o-example/r-root/ou-target/' }
+      })
+
+      //When checking the condition in Discovery mode
+      const result = requestMatchesConditions(req, cond, 'Allow', {
+        simulationMode: 'Discovery',
+        discoveryContextKeyConstraints: new DiscoveryContextKeyConstraints([])
+      })
+
+      //Then ForAnyValue already fails on a missing key and is reported through the normal no-match path
+      expect(result.matches).toBe('Match')
+      expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceOrgPaths'])
+      expect(result.details.conditions?.[0].failedBecauseMissing).toBe(true)
     })
 
     it('should not match Deny ForAnyValue when presence is known and the key is absent', () => {

--- a/src/condition/condition.ts
+++ b/src/condition/condition.ts
@@ -161,18 +161,19 @@ export function requestMatchesConditions(
     if (simulationParameters.simulationMode !== 'Discovery') {
       return false
     }
+
+    const constraint = simulationParameters.discoveryContextKeyConstraints.constraintFor(
+      c.condition.conditionKey()
+    )
     if (c.knowledge.conditionResult !== 'known') {
       if (normalizedStatementType === 'allow') {
-        return !c.explain.matches
+        return !c.explain.matches || allowMatchedOnlyByUnknownMissingKey(c)
       }
       if (normalizedStatementType === 'deny') {
         return true
       }
     }
 
-    const constraint = simulationParameters.discoveryContextKeyConstraints.constraintFor(
-      c.condition.conditionKey()
-    )
     if (constraint.explicitlyConfigured) {
       return false
     }
@@ -336,7 +337,7 @@ function discoveryKnowledgeForConditionKey(
 
   const constraint = simulationParameters.discoveryContextKeyConstraints.constraintFor(key)
   if (!constraint.explicitlyConfigured) {
-    return requestContextKeyKnowledge(keyExists)
+    return keyExists ? requestContextKeyKnowledge(keyExists) : unknownContextKeyKnowledge()
   }
 
   const contextKeyPresence: DiscoveryKnowledgeState = constraint.presenceIsKnown
@@ -416,6 +417,51 @@ function requestContextKeyKnowledge(keyExists: boolean): DiscoveryContextKeyKnow
     contextKeyPresence: 'known',
     contextKeyValue: keyExists ? 'known' : 'not-applicable'
   }
+}
+
+/**
+ * Builds context-key knowledge for an absent unconstrained Discovery key.
+ *
+ * In Discovery mode, an absent synthetic request-context value does not prove
+ * that the real request context lacks an unconstrained key.
+ *
+ * @returns context-key knowledge with unknown presence and value
+ */
+function unknownContextKeyKnowledge(): DiscoveryContextKeyKnowledge {
+  return {
+    contextKeyPresence: 'unknown',
+    contextKeyValue: 'unknown'
+  }
+}
+
+/**
+ * Checks whether an Allow condition should be reported because it matched only
+ * by missing-key semantics while the key's presence is unknown.
+ *
+ * `IfExists` and `ForAllValues` operators can match missing keys. Bare negative
+ * operators such as `StringNotEquals` can also match missing keys. When key
+ * presence is unknown, those matches are conditional on the real request also
+ * lacking the key. `ForAnyValue` missing-key evaluations do not match, so they
+ * are reported through the normal non-matching Allow condition path instead.
+ *
+ * @param conditionAndExplain the evaluated condition and its Discovery knowledge
+ * @returns true when the condition should be surfaced as an ignored Allow condition
+ */
+function allowMatchedOnlyByUnknownMissingKey(conditionAndExplain: ConditionAndExplain): boolean {
+  if (conditionAndExplain.explain.matchedBecauseMissing !== true) {
+    return false
+  }
+
+  const operation = conditionAndExplain.condition.operation()
+  if (operation.isIfExists()) {
+    return true
+  }
+  if (operation.setOperator() === 'ForAnyValue') {
+    return false
+  }
+
+  const baseOperation = baseOperations[operation.baseOperator().toLowerCase()]
+  return !!baseOperation?.isNegative
 }
 
 /**

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/identityAllow.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/identityAllow.json
@@ -97,5 +97,371 @@
     "expected": {
       "response": "ImplicitlyDenied"
     }
+  },
+  {
+    "name": "Allowed with condition when identity Allow negative condition key is unconstrained and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*",
+            "Condition": {
+              "StringNotEquals": {
+                "s3:ResourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "s3:ResourceAccount",
+              "op": "StringNotEquals",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEquals",
+        "key": "s3:ResourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Allowed with deny escape when identity Deny negative condition key is unconstrained and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*",
+            "Condition": {
+              "StringNotEquals": {
+                "s3:ResourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "deny": [
+            {
+              "key": "s3:ResourceAccount",
+              "op": "StringNotEquals",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "s3:ResourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 2
+          }
+        ],
+        "inverted": true
+      }
+    }
+  },
+  {
+    "name": "Allowed with condition when identity Allow StringEqualsIfExists key presence is unknown and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*",
+            "Condition": {
+              "StringEqualsIfExists": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringEqualsIfExists",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEqualsIfExists",
+        "key": "aws:SourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Allowed with condition when identity Allow StringNotEqualsIfExists key presence is unknown and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*",
+            "Condition": {
+              "StringNotEqualsIfExists": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringNotEqualsIfExists",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEqualsIfExists",
+        "key": "aws:SourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Allowed with condition when identity Allow ForAllValues StringNotEquals key is unconstrained and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*",
+            "Condition": {
+              "ForAllValues:StringNotEquals": {
+                "aws:SourceOrgPaths": "o-example/r-root/ou-target/"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceOrgPaths",
+              "op": "ForAllValues:StringNotEquals",
+              "values": ["o-example/r-root/ou-target/"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "ForAllValues:StringNotEquals",
+        "key": "aws:SourceOrgPaths",
+        "values": ["o-example/r-root/ou-target/"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Allowed with condition when identity Allow ForAnyValue StringNotEquals key is unconstrained and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:GetBucketAcl",
+            "Resource": "*",
+            "Condition": {
+              "ForAnyValue:StringNotEquals": {
+                "aws:SourceOrgPaths": "o-example/r-root/ou-target/"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceOrgPaths",
+              "op": "ForAnyValue:StringNotEquals",
+              "values": ["o-example/r-root/ou-target/"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "ForAnyValue:StringNotEquals",
+        "key": "aws:SourceOrgPaths",
+        "values": ["o-example/r-root/ou-target/"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
   }
 ]

--- a/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/resources.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/ignoredConditions/resources.json
@@ -289,5 +289,67 @@
         ]
       }
     }
+  },
+  {
+    "name": "Allow resource policy with condition when negative condition key is unconstrained and absent",
+    "request": {
+      "action": "s3:GetBucketAcl",
+      "resource": {
+        "resource": "arn:aws:s3:::example-bucket",
+        "accountId": "111111111111"
+      },
+      "principal": "arn:aws:iam::111111111111:role/test-role",
+      "context": {}
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "s3:GetBucketAcl",
+          "Resource": "arn:aws:s3:::example-bucket",
+          "Principal": {
+            "AWS": "arn:aws:iam::111111111111:role/test-role"
+          },
+          "Condition": {
+            "StringNotEquals": {
+              "s3:ResourceAccount": "111111111111"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery"
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "resource": {
+          "allow": [
+            {
+              "key": "s3:ResourceAccount",
+              "op": "StringNotEquals",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEquals",
+        "key": "s3:ResourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "ResourcePolicy",
+            "policyType": "resource",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
   }
 ]


### PR DESCRIPTION
## Summary
- Treat absent unconstrained Discovery context keys as unknown instead of known absent
- Surface Allow conditions that match only through missing-key semantics, including IfExists and ForAllValues negative cases
- Add unit and JSON core-engine integration coverage for Allow/Deny missing-key condition output

## Tests
- npm run build
- npm test
- npm run format-check