### PR TITLE
fix: report unknown-value conditions in discovery

### DIFF
--- a/src/condition/condition.test.ts
+++ b/src/condition/condition.test.ts
@@ -1919,8 +1919,9 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
     expect(result.ignoredConditions).toBeUndefined()
   })
 
-  it('should not report Allow value comparisons as ignored when value the same', () => {
-    //Given a present SourceAccount key with a non-authoritative placeholder value
+  it('should report Allow value comparisons as ignored when value is unknown and placeholder matches', () => {
+    //Given a present SourceAccount key with a placeholder matching the policy value
+    //And the Discovery constraint says the real concrete value is not known
     const req = new AwsRequestImpl(
       '',
       { resource: '', accountId: '' },
@@ -1937,9 +1938,9 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       discoveryWithConstraint('aws:SourceAccount', true, false)
     )
 
-    //Then the statement should match without any ignored conditions
+    //Then the placeholder match should not hide the unknown-value requirement
     expect(result.matches).toBe('Match')
-    expect(result.ignoredConditions).toBeUndefined()
+    expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
   })
 
   it('should report Allow value comparisons as ignored when value is unknown and different', () => {
@@ -1965,7 +1966,7 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
     expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
   })
 
-  it('should report Deny value comparisons as ignored when value is unknown', () => {
+  it('should report Deny value comparisons as ignored when value is unknown and different', () => {
     //Given a present SourceAccount key with a non-authoritative placeholder value
     const req = new AwsRequestImpl(
       '',
@@ -1984,6 +1985,30 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
     )
 
     //Then the possible deny should not definitively match but should be reported
+    expect(result.matches).toBe('NoMatch')
+    expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
+  })
+
+  it('should report Deny value comparisons as ignored when value is unknown and placeholder matches', () => {
+    //Given a present SourceAccount key with a placeholder matching the Deny policy value
+    //And the Discovery constraint says the real concrete value is not known
+    const req = new AwsRequestImpl(
+      '',
+      { resource: '', accountId: '' },
+      '',
+      new RequestContextImpl({ 'aws:SourceAccount': '111111111111' })
+    )
+    const cond = conditionsFor('Deny', { StringEquals: { 'aws:SourceAccount': '111111111111' } })
+
+    //When checking a Deny condition in Discovery mode
+    const result = requestMatchesConditions(
+      req,
+      cond,
+      'Deny',
+      discoveryWithConstraint('aws:SourceAccount', true, false)
+    )
+
+    //Then the placeholder match should not make the Deny definitive
     expect(result.matches).toBe('NoMatch')
     expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceAccount'])
   })
@@ -2034,6 +2059,29 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
     )
 
     //Then the condition should be reported as ignored instead of using the placeholder value
+    expect(result.matches).toBe('Match')
+    expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['s3:prefix'])
+  })
+
+  it('should report matching policy values that reference unknown-value keys as ignored', () => {
+    //Given a known s3 prefix matching an unknown SourceAccount placeholder used as a policy variable
+    const req = new AwsRequestImpl(
+      '',
+      { resource: '', accountId: '' },
+      '',
+      new RequestContextImpl({ 's3:prefix': '000000000000', 'aws:SourceAccount': '000000000000' })
+    )
+    const cond = conditionsFor('Allow', { StringEquals: { 's3:prefix': '${aws:SourceAccount}' } })
+
+    //When checking the condition in Discovery mode
+    const result = requestMatchesConditions(
+      req,
+      cond,
+      'Allow',
+      discoveryWithConstraint('aws:SourceAccount', true, false)
+    )
+
+    //Then the placeholder match should not hide the unknown policy-variable requirement
     expect(result.matches).toBe('Match')
     expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['s3:prefix'])
   })
@@ -2383,8 +2431,8 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
       expect(result.details.conditions?.[0].failedBecauseMissing).toBe(true)
     })
 
-    it('should match ForAnyValue when presence is known and the value matches', () => {
-      //Given an absent SourceOrgPaths key whose absence is authoritative
+    it('should report ForAnyValue as ignored when presence is known but the matching value is unknown', () => {
+      //Given a present SourceOrgPaths key with a matching but non-authoritative array value
       const req = requestWithContext({ 'aws:SourceOrgPaths': ['o-example/r-root/ou-target/'] })
       const cond = conditionsFor('Allow', {
         'ForAnyValue:StringEquals': { 'aws:SourceOrgPaths': 'o-example/r-root/ou-target/' }
@@ -2398,9 +2446,9 @@ describe('requestMatchesConditions - Discovery context key constraints', () => {
         discoveryWithConstraint('aws:SourceOrgPaths', true, false)
       )
 
-      //Then ForAnyValue should not match because the key is definitively absent
+      //Then the matching set operator should still be reported as an unknown-value requirement
       expect(result.matches).toBe('Match')
-      expect(result.ignoredConditions).toBeUndefined()
+      expect(result.ignoredConditions?.map((c) => c.conditionKey())).toEqual(['aws:SourceOrgPaths'])
     })
 
     it('should report ForAnyValue as ignored when presence is unknown and the key is absent', () => {

--- a/src/condition/condition.ts
+++ b/src/condition/condition.ts
@@ -167,7 +167,11 @@ export function requestMatchesConditions(
     )
     if (c.knowledge.conditionResult !== 'known') {
       if (normalizedStatementType === 'allow') {
-        return !c.explain.matches || allowMatchedOnlyByUnknownMissingKey(c)
+        return (
+          !c.explain.matches ||
+          allowMatchedOnlyByUnknownMissingKey(c) ||
+          allowHasUnknownValueRequirement(c)
+        )
       }
       if (normalizedStatementType === 'deny') {
         return true
@@ -462,6 +466,26 @@ function allowMatchedOnlyByUnknownMissingKey(conditionAndExplain: ConditionAndEx
 
   const baseOperation = baseOperations[operation.baseOperator().toLowerCase()]
   return !!baseOperation?.isNegative
+}
+
+/**
+ * Checks whether an Allow condition should be reported because Discovery knows
+ * the key is present but not enough value-level facts to trust a placeholder match.
+ *
+ * When `conditionResult` is already unknown, presence is known, and the key has
+ * an applicable value, the uncertainty comes from either the condition key's
+ * concrete value or a policy variable referenced by the condition value. In both
+ * cases a matching placeholder must still be surfaced as an ignored/output
+ * requirement.
+ *
+ * @param conditionAndExplain the evaluated condition and its Discovery knowledge
+ * @returns true when a matched Allow condition still has an unknown value requirement
+ */
+function allowHasUnknownValueRequirement(conditionAndExplain: ConditionAndExplain): boolean {
+  return (
+    conditionAndExplain.knowledge.contextKeyPresence === 'known' &&
+    conditionAndExplain.knowledge.contextKeyValue !== 'not-applicable'
+  )
 }
 
 /**

--- a/src/core_engine/coreEngineTests/discoveryMode/contextKeyConstraints/sourceContext.json
+++ b/src/core_engine/coreEngineTests/discoveryMode/contextKeyConstraints/sourceContext.json
@@ -69,6 +69,180 @@
     }
   },
   {
+    "name": "Allow condition with known presence and unknown value is ignored when placeholder matches",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/Alice",
+      "context": {
+        "aws:SourceAccount": "111111111111"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery",
+      "discoveryContextKeyConstraints": [
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "allow": [
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringEquals",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringEquals",
+        "key": "aws:SourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Allow",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 1
+          }
+        ]
+      }
+    }
+  },
+  {
+    "name": "Service principal resource allow reports matching SourceAccount and different SourceArn unknown values",
+    "request": {
+      "action": "sqs:SendMessage",
+      "resource": {
+        "resource": "arn:aws:sqs:us-east-1:111111111111:example-queue",
+        "accountId": "111111111111"
+      },
+      "principal": "s3.amazonaws.com",
+      "context": {
+        "aws:SourceAccount": "111111111111",
+        "aws:SourceArn": "arn:aws:iam::000000000000:role/unknown-source"
+      }
+    },
+    "identityPolicies": [],
+    "resourcePolicy": {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Action": "sqs:SendMessage",
+          "Resource": "arn:aws:sqs:us-east-1:111111111111:example-queue",
+          "Principal": {
+            "Service": "s3.amazonaws.com"
+          },
+          "Condition": {
+            "StringEquals": {
+              "aws:SourceAccount": "111111111111"
+            },
+            "ArnEquals": {
+              "aws:SourceArn": "arn:aws:s3:::example-source-bucket"
+            }
+          }
+        }
+      ]
+    },
+    "simulation": {
+      "mode": "Discovery",
+      "discoveryContextKeyConstraints": [
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        },
+        {
+          "keyName": "aws:SourceArn",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "resource": {
+          "allow": [
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringEquals",
+              "values": ["111111111111"]
+            },
+            {
+              "key": "aws:SourceArn",
+              "op": "ArnEquals",
+              "values": ["arn:aws:s3:::example-source-bucket"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "group",
+        "operator": "and",
+        "conditions": [
+          {
+            "conditionType": "condition",
+            "op": "StringEquals",
+            "key": "aws:SourceAccount",
+            "values": ["111111111111"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          },
+          {
+            "conditionType": "condition",
+            "op": "ArnEquals",
+            "key": "aws:SourceArn",
+            "values": ["arn:aws:s3:::example-source-bucket"],
+            "sources": [
+              {
+                "effect": "Allow",
+                "policyIdentifier": "ResourcePolicy",
+                "policyType": "resource",
+                "statementIndex": 1
+              }
+            ]
+          }
+        ]
+      }
+    }
+  },
+  {
     "name": "Deny condition with known presence and unknown value is ignored",
     "request": {
       "action": "s3:ListBucket",
@@ -79,6 +253,81 @@
       "principal": "arn:aws:iam::123456789012:user/Alice",
       "context": {
         "aws:SourceAccount": "000000000000"
+      }
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "s3:ListBucket",
+            "Resource": "*"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "s3:ListBucket",
+            "Resource": "*",
+            "Condition": {
+              "StringEquals": {
+                "aws:SourceAccount": "111111111111"
+              }
+            }
+          }
+        ]
+      }
+    ],
+    "simulation": {
+      "mode": "Discovery",
+      "discoveryContextKeyConstraints": [
+        {
+          "keyName": "aws:SourceAccount",
+          "presenceIsKnown": true,
+          "valueIsKnown": false
+        }
+      ]
+    },
+    "expected": {
+      "response": "Allowed",
+      "ignoredConditions": {
+        "identity": {
+          "deny": [
+            {
+              "key": "aws:SourceAccount",
+              "op": "StringEquals",
+              "values": ["111111111111"]
+            }
+          ]
+        }
+      },
+      "conditions": {
+        "conditionType": "condition",
+        "op": "StringNotEquals",
+        "key": "aws:SourceAccount",
+        "values": ["111111111111"],
+        "sources": [
+          {
+            "effect": "Deny",
+            "policyIdentifier": "0",
+            "policyType": "identity",
+            "statementIndex": 2
+          }
+        ],
+        "inverted": true
+      }
+    }
+  },
+  {
+    "name": "Deny condition with known presence and unknown value is ignored when placeholder matches",
+    "request": {
+      "action": "s3:ListBucket",
+      "resource": {
+        "resource": "*",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/Alice",
+      "context": {
+        "aws:SourceAccount": "111111111111"
       }
     },
     "identityPolicies": [


### PR DESCRIPTION
## Summary
- Report Discovery-mode Allow conditions as ignored/output requirements when their value-level facts are unknown, even if the placeholder evaluation matches
- Preserve absent-key semantics by excluding non-applicable values from the new unknown-value Allow predicate
- Add unit and core engine coverage for matching-placeholder Allow and Deny conditions, policy-variable values, set operators, and service-principal SourceAccount/SourceArn resource-policy requirements

## Tests
- npm run build
- npm test
- npm run format-check
