### PR TITLE
fix: handle KMS alias authorization

### DIFF
--- a/src/core_engine/coreEngineTests/kms/aliases.json
+++ b/src/core_engine/coreEngineTests/kms/aliases.json
@@ -1,0 +1,196 @@
+[
+  {
+    "name": "Allowed for same-account customer alias delete when identity policy allows",
+    "request": {
+      "action": "kms:DeleteAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/example-key",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:DeleteAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/example-key"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Allowed for same-account customer alias create when identity policy allows",
+    "request": {
+      "action": "kms:CreateAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/example-key",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:CreateAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/example-key"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Allowed for same-account customer alias update when identity policy allows",
+    "request": {
+      "action": "kms:UpdateAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/example-key",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:UpdateAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/example-key"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "Allowed"
+    }
+  },
+  {
+    "name": "Implicitly denied for AWS-managed alias delete action",
+    "request": {
+      "action": "kms:DeleteAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:DeleteAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
+  },
+  {
+    "name": "Implicitly denied for AWS-managed alias create action",
+    "request": {
+      "action": "kms:CreateAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:CreateAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
+  },
+  {
+    "name": "Implicitly denied for AWS-managed alias update action",
+    "request": {
+      "action": "kms:UpdateAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:UpdateAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ImplicitlyDenied"
+    }
+  },
+  {
+    "name": "Explicitly denied for AWS-managed alias when identity policy explicitly denies",
+    "request": {
+      "action": "kms:DeleteAlias",
+      "resource": {
+        "resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3",
+        "accountId": "123456789012"
+      },
+      "principal": "arn:aws:iam::123456789012:user/test-user",
+      "context": {}
+    },
+    "identityPolicies": [
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": "kms:DeleteAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3"
+          },
+          {
+            "Effect": "Deny",
+            "Action": "kms:DeleteAlias",
+            "Resource": "arn:aws:kms:us-east-1:123456789012:alias/aws/s3"
+          }
+        ]
+      }
+    ],
+    "expected": {
+      "response": "ExplicitlyDenied"
+    }
+  }
+]

--- a/src/services/KmsServiceAuthorizer.ts
+++ b/src/services/KmsServiceAuthorizer.ts
@@ -1,24 +1,92 @@
-import { type ResourceAnalysis } from '../evaluate.js'
+import { type RequestAnalysis, type ResourceAnalysis } from '../evaluate.js'
 import { type RequestResource } from '../request/requestResource.js'
 import { DefaultServiceAuthorizer, type PrincipalAccountTrust } from './DefaultServiceAuthorizer.js'
+import { type ServiceAuthorizationRequest } from './ServiceAuthorizer.js'
+
+const deniedActionsForAwsManagedAliases = new Set([
+  'kms:createalias',
+  'kms:deletealias',
+  'kms:updatealias'
+])
+const awsManagedAliasPrefix = 'alias/aws/'
 
 /**
- * The default authorizer for services.
+ * Checks whether the KMS resource should use KMS key-policy principal-account trust behavior.
+ *
+ * @param resource the request resource to classify
+ * @returns true when the resource is all resources or a KMS key resource
+ */
+function usesKmsKeyPrincipalAccountTrust(resource: RequestResource): boolean {
+  return resource.isAllResources() || resource.resource().toLowerCase().startsWith('key/')
+}
+
+/**
+ * Checks whether the KMS resource is an AWS-managed key alias.
+ *
+ * @param resource the request resource to classify
+ * @returns true when the resource is an alias/aws/... ARN resource
+ */
+function isAwsManagedAlias(resource: RequestResource): boolean {
+  return (
+    resource
+      .resource()
+      .slice(0, awsManagedAliasPrefix.length)
+      .localeCompare(awsManagedAliasPrefix, undefined, { sensitivity: 'accent' }) === 0
+  )
+}
+
+/**
+ * Service authorizer for AWS KMS requests.
  */
 export class KmsServiceAuthorizer extends DefaultServiceAuthorizer {
   /**
-   * Determines if the service trusts the principal's Account's IAM policies
+   * Authorize a KMS service request after policy analysis and KMS-specific managed alias checks.
    *
-   * @param sameAccount - If the principal and resource are in the same account
-   * @param resourceAnalysis - The resource policy analysis
-   * @returns how the service trusts the principal's account IAM policies
+   * @param request the service authorization request containing all analyses
+   * @returns the KMS authorization result
+   */
+  public override authorize(request: ServiceAuthorizationRequest): RequestAnalysis {
+    const baseResult = super.authorize(request)
+
+    if (baseResult.result === 'ExplicitlyDenied') {
+      return baseResult
+    }
+
+    if (
+      deniedActionsForAwsManagedAliases.has(request.request.action.value().toLowerCase()) &&
+      isAwsManagedAlias(request.request.resource)
+    ) {
+      return {
+        ...baseResult,
+        result: 'ImplicitlyDenied',
+        conditions: undefined
+      }
+    }
+
+    return baseResult
+  }
+
+  /**
+   * Determines how KMS trusts the principal account's IAM policies.
+   *
+   * KMS key resources keep KMS key-policy trust behavior, while other KMS resource types use the
+   * default service authorizer trust behavior.
+   *
+   * @param sameAccount if the principal and resource are in the same account
+   * @param resourceAnalysis the resource policy analysis
+   * @param resource the request resource used to choose key or default trust behavior
+   * @returns how KMS trusts the principal account's IAM policies
    */
   override serviceTrustsPrincipalAccount(
     sameAccount: boolean,
     resourceAnalysis: ResourceAnalysis,
     resource: RequestResource
   ): PrincipalAccountTrust {
-    if (sameAccount && resource.value() == '*') {
+    if (!usesKmsKeyPrincipalAccountTrust(resource)) {
+      return super.serviceTrustsPrincipalAccount(sameAccount, resourceAnalysis, resource)
+    }
+
+    if (sameAccount && resource.isAllResources()) {
       return { trustType: 'Implicit' }
     }
 


### PR DESCRIPTION
## Summary

- keep existing KMS key/wildcard principal-account trust behavior while delegating KMS aliases/non-key resources to the default authorizer trust behavior
- implicitly deny AWS-managed alias mutations for `kms:CreateAlias`, `kms:DeleteAlias`, and `kms:UpdateAlias`
- preserve explicit denies and add KMS alias authorization scenarios

## Tests

- `npx vitest --run src/core_engine/coreSimulatorEngine.test.ts`
- `npm run build`
- `npm test`
- `npm run format-check`
